### PR TITLE
Respect entity bounding boxes when adding new parts. Fixes #3

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
@@ -122,7 +122,7 @@ public abstract class AbstractPart {
      * called if the shape of one of the parts is completely contained by the shape of the other part.
      * <p>
      * This is called once for each part currently contained in a {@link MultipartContainer} in
-     * {@link MultipartContainer#offerNewPart(MultipartCreator)}. */
+     * {@link MultipartContainer#offerNewPart(MultipartCreator, boolean)}. */
     public boolean canOverlapWith(AbstractPart other) {
         return false;
     }

--- a/src/main/java/alexiil/mc/lib/multipart/api/MultipartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/MultipartContainer.java
@@ -104,14 +104,14 @@ public interface MultipartContainer {
      * the client <em>cannot</em> add the resulting part offer to this container.
      * 
      * @param creator The creator which can create the actual part.
-     * @param respectEntityBBs
+     * @param respectEntityBBs whether to respect nearby entities bounding boxes, or not
      * @return either null (if the offered part was refused) or an offer object which lets you either add it via
      *         {@link PartOffer#apply()}, or do nothing */
     @Nullable
     PartOffer offerNewPart(MultipartCreator creator, boolean respectEntityBBs);
 
-    /** Offers a new part to this container. Note that this can be called on the client as well as the server, however
-     * the client <em>cannot</em> add the resulting part offer to this container.
+    /** Offers a new part to this container, respecting nearby entities' bounding boxes. Note that this can be called on
+     * the client as well as the server, however the client <em>cannot</em> add the resulting part offer to this container.
      *
      * @param creator The creator which can create the actual part.
      * @return either null (if the offered part was refused) or an offer object which lets you either add it via
@@ -128,7 +128,7 @@ public interface MultipartContainer {
      * @return The holder for the part if it was added, or null if it was not. */
     @Nullable
     default MultipartHolder addNewPart(MultipartCreator creator, boolean respectEntityBBs) {
-        PartOffer offer = offerNewPart(creator, true);
+        PartOffer offer = offerNewPart(creator, respectEntityBBs);
         if (offer == null) {
             return null;
         }
@@ -136,6 +136,9 @@ public interface MultipartContainer {
         return offer.getHolder();
     }
 
+    /** Shorter form of {@link #offerNewPart(MultipartCreator, boolean)} followed by adding the offer if it was allowed.
+     *
+     * @return The holder for the part if it was added, or null if it was not. */
     default MultipartHolder addNewPart(MultipartCreator creator) {
         return addNewPart(creator, true);
     }

--- a/src/main/java/alexiil/mc/lib/multipart/api/MultipartUtil.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/MultipartUtil.java
@@ -29,8 +29,8 @@ public final class MultipartUtil {
         return MultipartUtilImpl.get(world, pos);
     }
 
-    /** Offers the given {@link AbstractPart} into the block at the given position. This may return a non-null
-     * {@link PartOffer} if */
+    /** Offers the given {@link AbstractPart} into the block at the given position, respecting nearby entities' bounding boxes.
+     * This may return a non-nul {@link PartOffer} if */
     @Nullable
     public static PartOffer offerNewPart(World world, BlockPos pos, MultipartCreator creator) {
         return offerNewPart(world, pos, creator, true);

--- a/src/main/java/alexiil/mc/lib/multipart/api/MultipartUtil.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/MultipartUtil.java
@@ -33,7 +33,14 @@ public final class MultipartUtil {
      * {@link PartOffer} if */
     @Nullable
     public static PartOffer offerNewPart(World world, BlockPos pos, MultipartCreator creator) {
-        return MultipartUtilImpl.offerNewPart(world, pos, creator);
+        return offerNewPart(world, pos, creator, true);
+    }
+
+    /** Offers the given {@link AbstractPart} into the block at the given position. This may return a non-null
+     * {@link PartOffer} if */
+    @Nullable
+    public static PartOffer offerNewPart(World world, BlockPos pos, MultipartCreator creator, boolean respectEntityBBs) {
+        return MultipartUtilImpl.offerNewPart(world, pos, creator, respectEntityBBs);
     }
 
     /** Turns an existing {@link NativeMultipart} block into a {@link BlockEntity} based {@link MultipartContainer}.

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartOfferedEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartOfferedEvent.java
@@ -11,7 +11,7 @@ import alexiil.mc.lib.multipart.api.AbstractPart;
 import alexiil.mc.lib.multipart.api.MultipartContainer;
 import alexiil.mc.lib.multipart.api.MultipartContainer.MultipartCreator;
 
-/** Fired whenever an {@link AbstractPart} is {@link MultipartContainer#offerNewPart(MultipartCreator) offered} or
+/** Fired whenever an {@link AbstractPart} is {@link MultipartContainer#offerNewPart(MultipartCreator, boolean) offered} or
  * {@link MultipartContainer#addNewPart(MultipartCreator) added} to a {@link MultipartContainer}. */
 public final class PartOfferedEvent extends MultipartEvent {
     public final AbstractPart part;

--- a/src/main/java/alexiil/mc/lib/multipart/api/package-info.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/package-info.java
@@ -73,7 +73,7 @@
  * {@link alexiil.mc.lib.multipart.api.MultipartUtil#offerNewPart(net.minecraft.world.World, net.minecraft.util.math.BlockPos, alexiil.mc.lib.multipart.api.MultipartContainer.MultipartCreator)
  * MultipartUtil.offerNewPart(World, BlockPos, MultipartContainer.MultipartCreator)}</li>
  * <li>To an existing MultipartContainer:
- * {@link alexiil.mc.lib.multipart.api.MultipartContainer#offerNewPart(alexiil.mc.lib.multipart.api.MultipartContainer.MultipartCreator)
+ * {@link alexiil.mc.lib.multipart.api.MultipartContainer#offerNewPart(MultipartContainer.MultipartCreator, boolean)
  * MultipartContainer.offerNewpart(MultipartContainer.MultipartCreator)}</li>
  * </ol>
  * Both of these methods have the same basic behaviour: they will not affect the world/container unless

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -204,7 +204,7 @@ public class PartContainer implements MultipartContainer {
     @Override
     public PartOffer offerNewPart(MultipartCreator creator, boolean respectEntityBBs) {
         PartHolder holder = new PartHolder(this, creator);
-        if (!canAdd(holder, true)) {
+        if (!canAdd(holder, respectEntityBBs)) {
             return null;
         }
         return new PartOffer() {

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -202,9 +202,9 @@ public class PartContainer implements MultipartContainer {
     }
 
     @Override
-    public PartOffer offerNewPart(MultipartCreator creator) {
+    public PartOffer offerNewPart(MultipartCreator creator, boolean respectEntityBBs) {
         PartHolder holder = new PartHolder(this, creator);
-        if (!canAdd(holder)) {
+        if (!canAdd(holder, true)) {
             return null;
         }
         return new PartOffer() {
@@ -221,17 +221,19 @@ public class PartContainer implements MultipartContainer {
         };
     }
 
+
+
     @Override
     public MultipartHolder addNewPart(MultipartCreator creator) {
         PartHolder holder = new PartHolder(this, creator);
-        if (!canAdd(holder)) {
+        if (!canAdd(holder, true)) {
             return null;
         }
         addPartInternal(holder);
         return holder;
     }
 
-    boolean canAdd(PartHolder offered) {
+    boolean canAdd(PartHolder offered, boolean respectEntityBBs) {
         VoxelShape currentShape = getCurrentShape();
         for (PartHolder holder : parts) {
             AbstractPart part = holder.part;
@@ -268,6 +270,14 @@ public class PartContainer implements MultipartContainer {
 
             // Check with each part for overlaps
             if (!part.canOverlapWith(offered.part) || !offered.part.canOverlapWith(part)) {
+                return false;
+            }
+        }
+
+        if(respectEntityBBs) {
+            VoxelShape collisionShape = offered.getPart().getCollisionShape();
+            BlockPos pos = getMultipartPos();
+            if ((!collisionShape.isEmpty()) && !getMultipartWorld().intersectsEntities(null, collisionShape.offset(pos.getX(), pos.getY(), pos.getZ()))) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR disallows to place parts if some entity intersects with it's collision bounding box. 