### PR TITLE
fix a couple edge case crashes

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
@@ -114,10 +114,12 @@ public class MultipartBlock extends Block
 
     @Override
     public VoxelShape getCollisionShape(BlockState state, BlockView view, BlockPos pos, ShapeContext ctx) {
-        BlockEntity be = view.getBlockEntity(pos);
-        if (be instanceof MultipartBlockEntity) {
-            MultipartBlockEntity container = (MultipartBlockEntity) be;
-            return container.container.getCollisionShape();
+        if (view != null) {
+            BlockEntity be = view.getBlockEntity(pos);
+            if (be instanceof MultipartBlockEntity) {
+                MultipartBlockEntity container = (MultipartBlockEntity) be;
+                return container.container.getCollisionShape();
+            }
         }
         return MISSING_PARTS_SHAPE;
     }
@@ -125,12 +127,12 @@ public class MultipartBlock extends Block
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView view, BlockPos pos, ShapeContext ctx) {
         BlockEntity be = view.getBlockEntity(pos);
-        if (be instanceof MultipartBlockEntity) {
+        if (be instanceof MultipartBlockEntity && view instanceof World) {
             MultipartBlockEntity container = (MultipartBlockEntity) be;
 
             if (LibMultiPart.isDrawingBlockOutlines.getAsBoolean()) {
                 Vec3d hitVec = MinecraftClient.getInstance().crosshairTarget.getPos();
-                return getPartOutlineShape(state, (World) view, pos, hitVec);
+                return getPartOutlineShape(state, (World)view, pos, hitVec);
             }
 
             return container.container.getOutlineShape();


### PR DESCRIPTION
getCollisionShape may crash when walking on multipart blocks, not sure what interaction specifically was causing it but I have attached a sample crash report.

getOutlineShape was crashing when a [Staff Of Building](https://www.curseforge.com/minecraft/mc-mods/staff-of-building) was held near a multipart block. Adding the instance check seems to resolve it without adversely impacting hitbox behavior. I have also attached that crash report.

[crash-2021-02-09_21.23.46-client.txt](https://github.com/AlexIIL/LibMultiPart/files/5974943/crash-2021-02-09_21.23.46-client.txt)
[crash-2021-02-10_21.15.27-client.txt](https://github.com/AlexIIL/LibMultiPart/files/5974944/crash-2021-02-10_21.15.27-client.txt)
