### PR TITLE
Fix sprint, fall, and iron golem particles

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
@@ -7,6 +7,7 @@
  */
 package alexiil.mc.lib.multipart.api;
 
+import java.util.Random;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -25,6 +26,9 @@ import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.passive.IronGolemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -84,6 +88,7 @@ public abstract class AbstractPart {
     public static final ParentNetIdSingle<AbstractPart> NET_ID;
     public static final NetIdDataK<AbstractPart> NET_RENDER_DATA;
     public static final NetIdSignalK<AbstractPart> NET_SPAWN_BREAK_PARTICLES;
+    public static final NetIdDataK<AbstractPart> NET_SPAWN_FALL_PARTICLES;
 
     static {
         NET_ID = PartContainer.NET_KEY_PART;
@@ -92,6 +97,8 @@ public abstract class AbstractPart {
         // never buffer break particles because otherwise the block will be removed before the particles can spawn
         NET_SPAWN_BREAK_PARTICLES = NET_ID.idSignal("spawn_break_particles").toClientOnly().withoutBuffering()
             .setReceiver(AbstractPart::spawnBreakParticles);
+        NET_SPAWN_FALL_PARTICLES = NET_ID.idData("spawn_fall_particles").toClientOnly()
+            .setReceiver(AbstractPart::spawnFallParticles);
     }
 
     public final PartDefinition definition;
@@ -144,7 +151,7 @@ public abstract class AbstractPart {
      * {@link BlockEntity#cancelRemoval()} or when it is manually added by an item.
      * <p>
      * Register event handlers (as methods) with {@link MultipartEventBus#addListener(Object, Class, EventListener)}.
-     * 
+     *
      * @param bus The event bus to register with. This is shorthand for
      *            <code>holder.getContainer().getEventBus()</code> */
     public void onAdded(MultipartEventBus bus) {
@@ -164,7 +171,7 @@ public abstract class AbstractPart {
 
     /** Called instead of {@link Block#onBreak(World, BlockPos, BlockState, PlayerEntity)}, to play the broken sound,
      * and spawn break particles.
-     * 
+     *
      * @return True if this should prevent {@link Block#onBreak(World, BlockPos, BlockState, PlayerEntity)} from being
      *         called afterwards, false otherwise. */
     public boolean onBreak(PlayerEntity player) {
@@ -184,7 +191,7 @@ public abstract class AbstractPart {
 
     /** Called instead of {@link Block#onBreak(World, BlockPos, BlockState, PlayerEntity)}, to play the broken sound,
      * and spawn break particles.
-     * 
+     *
      * @return True if this should prevent {@link Block#onBreak(World, BlockPos, BlockState, PlayerEntity)} from being
      *         called afterwards, false otherwise. */
     @Environment(EnvType.CLIENT)
@@ -225,7 +232,7 @@ public abstract class AbstractPart {
     }
 
     /** Spawns a single breaking particle.
-     * 
+     *
      * @param side The side that was hit
      * @return True to cancel the default breaking particle from spawning, false otherwise.
      * @deprecated This was renamed to {@link #spawnHitParticle(Direction)} */
@@ -236,7 +243,7 @@ public abstract class AbstractPart {
     }
 
     /** Spawns a single partial-break (hit) particle.
-     * 
+     *
      * @param side The side that was hit
      * @return True to cancel the default breaking particle from spawning, false otherwise. */
     @Environment(EnvType.CLIENT)
@@ -373,6 +380,182 @@ public abstract class AbstractPart {
         }
     }
 
+    /** Spawns a single sprint particle.
+     *
+     * @param sprintingEntity The entity doing the sprinting.
+     * @param entityRandom The entity's random for use in particle position &amp; velocity calculations.
+     * @return True to cancel the default sprinting particle from spawning, false otherwise. */
+    @Environment(EnvType.CLIENT)
+    public boolean spawnSprintParticle(Entity sprintingEntity, Random entityRandom) {
+        spawnSprintParticle(sprintingEntity, entityRandom, getClosestBlockState());
+        return true;
+    }
+
+    @Environment(EnvType.CLIENT)
+    protected final void spawnSprintParticle(Entity sprintingEntity, Random entityRandom, BlockState state) {
+        spawnSprintParticle(sprintingEntity, entityRandom, state, (Sprite) null);
+    }
+
+    @Environment(EnvType.CLIENT)
+    protected final void spawnSprintParticle(Entity sprintingEntity, Random entityRandom, BlockState state, @Nullable Identifier spriteId) {
+        Sprite sprite;
+        if (spriteId == null) {
+            sprite = null;
+        } else {
+            sprite = getBlockAtlas().apply(spriteId);
+        }
+        spawnSprintParticle(sprintingEntity, entityRandom, state, sprite);
+    }
+
+    @Environment(EnvType.CLIENT)
+    protected final void spawnSprintParticle(Entity sprintingEntity, Random entityRandom, BlockState state, @Nullable Sprite sprite) {
+        World world = holder.getContainer().getMultipartWorld();
+        BlockPos blockPos = holder.getContainer().getMultipartPos();
+        ParticleManager manager = MinecraftClient.getInstance().particleManager;
+
+        Vec3d velocity = sprintingEntity.getVelocity();
+        double width = sprintingEntity.getWidth();
+
+        double x = sprintingEntity.getX() + (entityRandom.nextDouble() - 0.5) * width;
+        double y = sprintingEntity.getY() + 0.1;
+        double z = sprintingEntity.getZ() + (entityRandom.nextDouble() - 0.5) * width;
+        double dx = velocity.x * -4.0;
+        double dy = 1.5;
+        double dz = velocity.z * -4.0;
+
+        BlockDustParticle particle = new BlockDustParticle((ClientWorld) world, x, y, z, dx, dy, dz, state, blockPos);
+        if (sprite != null) {
+            particle.setSprite(new SingleSpriteProvider(sprite));
+        }
+        manager.addParticle(particle);
+    }
+
+    /** Spawns a single particle for when an iron golem walks on this part.
+     *
+     * @param ironGolem The iron golem doing the walking.
+     * @param entityRandom The iron golem's random for use in particle position &amp; velocity calculations.
+     * @return True to cancel the default iron golem walking particle from spawning, false otherwise. */
+    @Environment(EnvType.CLIENT)
+    public boolean spawnIronGolemParticle(IronGolemEntity ironGolem, Random entityRandom) {
+        spawnIronGolemParticle(ironGolem, entityRandom, getClosestBlockState());
+        return true;
+    }
+
+    protected final void spawnIronGolemParticle(IronGolemEntity ironGolem, Random entityRandom, BlockState state) {
+        spawnIronGolemParticle(ironGolem, entityRandom, state, (Sprite) null);
+    }
+
+    protected final void spawnIronGolemParticle(IronGolemEntity ironGolem, Random entityRandom, BlockState state, @Nullable Identifier spriteId) {
+        Sprite sprite;
+        if (spriteId == null) {
+            sprite = null;
+        } else {
+            sprite = getBlockAtlas().apply(spriteId);
+        }
+        spawnIronGolemParticle(ironGolem, entityRandom, state, sprite);
+    }
+
+    protected final void spawnIronGolemParticle(IronGolemEntity ironGolem, Random entityRandom, BlockState state, @Nullable Sprite sprite) {
+        World world = holder.getContainer().getMultipartWorld();
+        BlockPos blockPos = holder.getContainer().getMultipartPos();
+        ParticleManager manager = MinecraftClient.getInstance().particleManager;
+
+        double width = ironGolem.getWidth();
+
+        double x = ironGolem.getX() + (entityRandom.nextDouble() - 0.5) * width;
+        double y = ironGolem.getY() + 0.1;
+        double z = ironGolem.getZ() + (entityRandom.nextDouble() - 0.5) * width;
+        double dx = (entityRandom.nextDouble() - 0.5) * 4.0;
+        double dy = 0.5;
+        double dz = (entityRandom.nextDouble() - 0.5) * 4.0;
+
+        BlockDustParticle particle = new BlockDustParticle((ClientWorld) world, x, y, z, dx, dy, dz, state, blockPos);
+        if (sprite != null) {
+            particle.setSprite(new SingleSpriteProvider(sprite));
+        }
+        manager.addParticle(particle);
+    }
+
+    /** Called on the server when an entity has fallen on this part and is attempting to spawn particles for it.
+     *
+     * This is to send packets to clients to actually spawn the particles.
+     *
+     * @param fallenEntity The entity that has just landed on this part.
+     * @param entityRandom The entity's random for use in particle position &amp; velocity calculations.
+     * @return True to cancel the default fall particle from spawning, false otherwise. */
+    public boolean onSpawnFallParticles(LivingEntity fallenEntity, Random entityRandom) {
+        float f = MathHelper.ceil(fallenEntity.fallDistance - 3.0f);
+        double d = Math.min(0.2f + f / 15.0f, 2.5);
+        int count = (int)(150.0 * d);
+        sendSpawnFallParticles(fallenEntity.getPos(), count);
+        return true;
+    }
+
+    /** Actually Sends the packet from the server to the clients that spawns the fall particles.
+     *
+     * @param pos The position of the particles to spawn.
+     * @param count The number of particles to spawn. */
+    protected final void sendSpawnFallParticles(Vec3d pos, int count) {
+        sendNetworkUpdate(this, NET_SPAWN_FALL_PARTICLES, (obj, buffer, ctx) -> {
+            ctx.assertServerSide();
+            buffer.writeDouble(pos.x);
+            buffer.writeDouble(pos.y);
+            buffer.writeDouble(pos.z);
+            buffer.writeInt(count);
+        });
+    }
+
+    private void spawnFallParticles(NetByteBuf buf, IMsgReadCtx ctx) {
+        Vec3d pos = new Vec3d(buf.readDouble(), buf.readDouble(), buf.readDouble());
+        int count = buf.readInt();
+        spawnFallParticles(pos, count);
+    }
+
+    /** Called on the client to spawn fall particles.
+     *
+     * By default, this calls {@link #spawnFallParticles(Vec3d, int, BlockState)} with {@link #getClosestBlockState()}
+     * as its {@link BlockState} parameter.
+     *
+     * @param pos The position of the particles to spawn.
+     * @param count The number of particles to spawn. */
+    protected void spawnFallParticles(Vec3d pos, int count) {
+        spawnFallParticles(pos, count, getClosestBlockState());
+    }
+
+    protected final void spawnFallParticles(Vec3d pos, int count, BlockState state) {
+        spawnFallParticles(pos, count, state, (Sprite) null);
+    }
+
+    protected final void spawnFallParticles(Vec3d pos, int count, BlockState state, @Nullable Identifier spriteId) {
+        Sprite sprite;
+        if (spriteId == null) {
+            sprite = null;
+        } else {
+            sprite = getBlockAtlas().apply(spriteId);
+        }
+        spawnFallParticles(pos, count, state, sprite);
+    }
+
+    protected final void spawnFallParticles(Vec3d pos, int count, BlockState state, @Nullable Sprite sprite) {
+        World world = holder.getContainer().getMultipartWorld();
+        BlockPos blockPos = holder.getContainer().getMultipartPos();
+        Random random = world.random;
+        ParticleManager manager = MinecraftClient.getInstance().particleManager;
+
+        for (int i = 0; i < count; i++) {
+            double dx = random.nextGaussian() * 0.15;
+            double dy = random.nextGaussian() * 0.15;
+            double dz = random.nextGaussian() * 0.15;
+            BlockDustParticle particle = new BlockDustParticle(
+                    (ClientWorld) world, pos.getX(), pos.getY(), pos.getZ(), dx, dy, dz, state, blockPos
+            );
+            if (sprite != null) {
+                particle.setSprite(new SingleSpriteProvider(sprite));
+            }
+            manager.addParticle(particle);
+        }
+    }
+
     protected final void addRequiredPart(AbstractPart required) {
         holder.addRequiredPart(required);
     }
@@ -447,7 +630,7 @@ public abstract class AbstractPart {
 
     /** Called whenever this part is picked by the player (similar to
      * {@link Block#getPickStack(BlockView, BlockPos, BlockState)})
-     * 
+     *
      * @return The stack that should be picked, or ItemStack.EMPTY if no stack can be picked from this part. */
     public ItemStack getPickStack() {
         return ItemStack.EMPTY;
@@ -540,14 +723,14 @@ public abstract class AbstractPart {
     }
 
     /** Called whenever {@link BlockEntity#applyRotation(BlockRotation)} is called on the containing block.
-     * 
+     *
      * @param rotation A rotation. LMP never calls this with {@link BlockRotation#NONE} */
     public void rotate(BlockRotation rotation) {
 
     }
 
     /** Called whenever {@link BlockEntity#applyMirror(BlockMirror)} is called on the containing block.
-     * 
+     *
      * @param mirror A mirror. LMP never calls this with {@link BlockMirror#NONE} */
     public void mirror(BlockMirror mirror) {
 
@@ -557,7 +740,7 @@ public abstract class AbstractPart {
      * {@link MultipartContainer#redrawIfChanged()}.
      * <p>
      * This is no longer called on the server.
-     * 
+     *
      * @return The {@link PartModelKey} for the {@link PartModelBaker} to use to emit a static model. Returning null
      *         will bake nothing. */
     @Nullable

--- a/src/main/java/alexiil/mc/lib/multipart/mixin/api/IBlockCustomParticles.java
+++ b/src/main/java/alexiil/mc/lib/multipart/mixin/api/IBlockCustomParticles.java
@@ -11,13 +11,27 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.passive.IronGolemEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
+import java.util.Random;
+
 public interface IBlockCustomParticles {
 
     @Environment(EnvType.CLIENT)
     boolean spawnBreakingParticles(World world, BlockPos pos, BlockState state, Direction side, Vec3d hitVec);
+
+    @Environment(EnvType.CLIENT)
+    boolean spawnSprintingParticles(World world, BlockPos pos, BlockState state, Entity sprintingEntity, Random entityRandom);
+
+    @Environment(EnvType.CLIENT)
+    boolean spawnIronGolemParticles(World world, BlockPos pos, BlockState state, IronGolemEntity ironGolem, Random entityRandom);
+
+    boolean spawnFallParticles(ServerWorld world, BlockPos pos, BlockState state, LivingEntity fallenEntity, Random entityRandom);
 }

--- a/src/main/java/alexiil/mc/lib/multipart/mixin/api/IBlockMultipart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/mixin/api/IBlockMultipart.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
@@ -83,4 +84,7 @@ public interface IBlockMultipart<T> {
             return null;
         }
     }
+
+    @Nullable
+    T getMultipartColliding(BlockState state, BlockView view, BlockPos pos, Box toCollideWith, double clearance);
 }

--- a/src/main/java/alexiil/mc/lib/multipart/mixin/impl/Client_EntityMixin.java
+++ b/src/main/java/alexiil/mc/lib/multipart/mixin/impl/Client_EntityMixin.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.mixin.impl;
+
+import alexiil.mc.lib.multipart.mixin.api.IBlockCustomParticles;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Random;
+
+@Mixin(Entity.class)
+public abstract class Client_EntityMixin {
+
+    @Shadow
+    public World world;
+
+    @Shadow
+    public abstract double getX();
+
+    @Shadow
+    public abstract double getY();
+
+    @Shadow
+    public abstract double getZ();
+
+    @Shadow
+    @Final
+    protected Random random;
+
+    @Inject(at = @At("HEAD"), method = "spawnSprintingParticles()V", cancellable = true)
+    private void spawnSprintingParticles(CallbackInfo ci) {
+        // The associated Entity method seems to be called on both the client and the server, but the call to
+        // `world.addParticle()` only does anything on the client.
+        if (world.isClient) {
+            BlockPos blockPos = new BlockPos(getX(), MathHelper.floor(getY() - 0.2), MathHelper.floor(getZ()));
+            BlockState state = world.getBlockState(blockPos);
+            Block block = state.getBlock();
+            if (block instanceof IBlockCustomParticles) {
+                if (((IBlockCustomParticles) block).spawnSprintingParticles(world, blockPos, state,
+                        (Entity) (Object) this,
+                        random)) {
+                    ci.cancel();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/mixin/impl/Client_IronGolemEntityMixin.java
+++ b/src/main/java/alexiil/mc/lib/multipart/mixin/impl/Client_IronGolemEntityMixin.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.mixin.impl;
+
+import alexiil.mc.lib.multipart.mixin.api.IBlockCustomParticles;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.Angerable;
+import net.minecraft.entity.passive.GolemEntity;
+import net.minecraft.entity.passive.IronGolemEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(IronGolemEntity.class)
+public abstract class Client_IronGolemEntityMixin extends GolemEntity implements Angerable {
+
+    protected Client_IronGolemEntityMixin(EntityType<? extends GolemEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Inject(at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/world/World;addParticle(Lnet/minecraft/particle/ParticleEffect;DDDDDD)V"),
+            method = "tickMovement()V", cancellable = true)
+    private void tickMovment(CallbackInfo ci) {
+        // The associated IronGolemEntity method seems to be called on both the client and the server, but the call to
+        // `world.addParticle()` only does anything on the client.
+        if (world.isClient) {
+            BlockPos pos =
+                    new BlockPos(MathHelper.floor(getX()), MathHelper.floor(getY() - 0.2), MathHelper.floor(getZ()));
+            BlockState state = world.getBlockState(pos);
+            Block block = state.getBlock();
+            if (block instanceof IBlockCustomParticles) {
+                if (((IBlockCustomParticles) block).spawnIronGolemParticles(world, pos, state,
+                        (IronGolemEntity) (Object) this, getRandom())) {
+                    ci.cancel();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/mixin/impl/LivingEntityMixin.java
+++ b/src/main/java/alexiil/mc/lib/multipart/mixin/impl/LivingEntityMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.mixin.impl;
+
+import alexiil.mc.lib.multipart.mixin.api.IBlockCustomParticles;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin extends Entity {
+
+    public LivingEntityMixin(EntityType<?> type, World world) {
+        super(type, world);
+    }
+
+    @Inject(at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/server/world/ServerWorld;spawnParticles(Lnet/minecraft/particle/ParticleEffect;DDDIDDDD)I"),
+            method = "fall(DZLnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V", cancellable = true)
+    private void fall(double heightDifference, boolean onGround, BlockState landedState, BlockPos landedPosition,
+                      CallbackInfo ci) {
+        BlockPos blockPos = new BlockPos(getX(), MathHelper.floor(getY() - 0.2), MathHelper.floor(getZ()));
+        BlockState state = world.getBlockState(blockPos);
+        Block block = state.getBlock();
+        if (block instanceof IBlockCustomParticles) {
+            // This injector injects into an if statement that checks `!world.isClient`
+            if (((IBlockCustomParticles) block).spawnFallParticles((ServerWorld) world, blockPos, state,
+                    (LivingEntity) (Object) this, random)) {
+                ci.cancel();
+
+                // Since we're canceling, the rest of this method won't run. We should do the things that would normally
+                // come after.
+                super.fall(heightDifference, onGround, landedState, landedPosition);
+            }
+        }
+    }
+}

--- a/src/main/resources/libmultipart.client.json
+++ b/src/main/resources/libmultipart.client.json
@@ -5,6 +5,8 @@
   "client": [
     "BlockRenderManagerMixin",
     "Client_BlockMixin",
+    "Client_EntityMixin",
+    "Client_IronGolemEntityMixin",
     "ClientPlayerInteractionManagerMixin",
     "ParticleManagerMixin",
     "WorldRendererMixin"

--- a/src/main/resources/libmultipart.common.json
+++ b/src/main/resources/libmultipart.common.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "BlockSoundGroupAccessor",
+    "LivingEntityMixin",
     "LootContextTypesAccessor",
     "ServerPlayerInteractionManagerMixin"
   ],


### PR DESCRIPTION
# This PR
This pull request fixes sprint, fall, and iron golem particles for multi-part blocks. This PR does so by mixing into classes that would spawn these particles, cancelling the default particle generation for multi-part blocks, and providing methods in `MultipartBlock` and then in `AbstractPart` for handling custom particle generation for these different types of particles.

## Mixins Added
* `Client_EntityMixin` - This mixin implements sprint particle overrides by injecting into `Entity.spawnSprintingParticles()` and calling `spawnSprintingParticles(...)` on the block being sprinted over if that block implements `IBlockCustomParticles`.
* `Client_IronGolemEntityMixin` - This mixin implements iron golem particle overrides the same way, but by calling `IBlockCustomParticles.spawnIronGolemParticles(...)`.
* `LivingEntityMixin` - This mixin implements fall particle overrides in a similar way to the previous two mixins except that it calls `IBlockCustomParticles.spawnFallParticles(...)` and that it is only called on the server.

## API Changes
* `AbstractPart` added methods:
   - `spawnSprintParticle(Entity sprintingEntity, Random entityRandom)` - Spawns a single sprint particle. This method can be overridden to provide custom sprint particle handling.
   - Protected, final `spawnSprintParticle` variants for spawning sprint particles with different `BlockState`s, `Identifier`s, and `Sprite`s.
   - `spawnIronGolemParticle(IronGolemEntity ironGolem, Random entityRandom)` - Spawns a single particle for when an iron golem walks on this part. This method can be overridden to provide custom iron golem particle handling.
   - Protected, final `spawnIronGolemParticle` variants for spawning iron golem particles with different `BlockState`s, `Identifier`s, and `Sprite`s.
   - `onSpawnFallParticles(LivingEntity fallenEntity, Random entityRandom)` - Called on the server when an entity has fallen on this part and is attempting to spawn particles for it. This method can be overridden to provide custom fall particle server-side handling.
   - Protected, final `sendSpawnFallParticles(Vec3d pos, int count)` - Actually Sends the packet from the server to the clients that spawns the fall particles.
   - Protected `spawnFallParticles(Vec3d pos, int count)` - Called on the client to spawn fall particles. This method can be overridden to provide custom fall particle client-side handling.
   - Protected, final `spawnFallParticles` variants for spawning fall particles with different `BlockState`s, `Identifier`s, and `Sprite`s.
* `AbstractPart` added public, static, final fields:
   - `NetIdDataK<AbstractPart> NET_SPAWN_FALL_PARTICLES` - For sending fall particles data from the server to the clients.

# Testing
This PR has been quickly tested in a creative world with VanillaParts. Tested sprint, fall, and iron golem particles render properly now. The test was conducted with sets of VanillaParts oak slab parts over top of stone button parts.

# Related Issues
This PR fixes #30 and fixes #34.