### PR TITLE
Improve thread-safety of PartContainer shape caches

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -152,10 +153,10 @@ public class PartContainer implements MultipartContainer {
     final Long2ObjectMap<PartHolder> partsByUid = new Long2ObjectOpenHashMap<>();
 
     MultipartBlockEntity blockEntity;
-    VoxelShape cachedShape = null;
-    VoxelShape cachedCollisionShape = null;
-    VoxelShape cachedCullingShape = null;
-    VoxelShape cachedOutlineShape = null;
+    AtomicReference<VoxelShape> cachedShape = new AtomicReference<>(null);
+    AtomicReference<VoxelShape> cachedCollisionShape = new AtomicReference<>(null);
+    AtomicReference<VoxelShape> cachedCullingShape = new AtomicReference<>(null);
+    AtomicReference<VoxelShape> cachedOutlineShape = new AtomicReference<>(null);
     boolean havePropertiesChanged = false;
     boolean hasTicked = false;
 
@@ -589,38 +590,45 @@ public class PartContainer implements MultipartContainer {
 
     @Override
     public VoxelShape getCurrentShape() {
+        VoxelShape cachedShape = this.cachedShape.get();
         if (cachedShape == null) {
             cachedShape = VoxelShapes.empty();
             for (PartHolder holder : parts) {
                 cachedShape = VoxelShapes.union(cachedShape, holder.part.getShape());
             }
+            this.cachedShape.set(cachedShape);
         }
         return cachedShape;
     }
 
     @Override
     public VoxelShape getCollisionShape() {
+        VoxelShape cachedCollisionShape = this.cachedCollisionShape.get();
         if (cachedCollisionShape == null) {
             cachedCollisionShape = VoxelShapes.empty();
             for (PartHolder holder : parts) {
                 cachedCollisionShape = VoxelShapes.union(cachedCollisionShape, holder.part.getCollisionShape());
             }
+            this.cachedCollisionShape.set(cachedCollisionShape);
         }
         return cachedCollisionShape;
     }
 
     public VoxelShape getCullingShape() {
+        VoxelShape cachedCullingShape = this.cachedCullingShape.get();
         if (cachedCullingShape == null) {
             cachedCullingShape = VoxelShapes.empty();
             for (PartHolder holder : parts) {
                 cachedCullingShape = VoxelShapes.union(cachedCullingShape, holder.part.getCullingShape());
             }
+            this.cachedCullingShape.set(cachedCullingShape);
         }
         return cachedCullingShape;
     }
 
     @Override
     public VoxelShape getOutlineShape() {
+        VoxelShape cachedOutlineShape = this.cachedOutlineShape.get();
         if (cachedOutlineShape == null) {
             cachedOutlineShape = VoxelShapes.empty();
             for (PartHolder holder : parts) {
@@ -629,16 +637,17 @@ public class PartContainer implements MultipartContainer {
             if (cachedOutlineShape.isEmpty()) {
                 cachedOutlineShape = VoxelShapes.empty();
             }
+            this.cachedOutlineShape.set(cachedOutlineShape);
         }
         return cachedOutlineShape;
     }
 
     @Override
     public void recalculateShape() {
-        cachedShape = null;
-        cachedCollisionShape = null;
-        cachedCullingShape = null;
-        cachedOutlineShape = null;
+        cachedShape.set(null);
+        cachedCollisionShape.set(null);
+        cachedCullingShape.set(null);
+        cachedOutlineShape.set(null);
     }
 
     @Override


### PR DESCRIPTION
# This PR
This pull request fixes the specific threading issue encountered in #37, where a `PartContainer`'s shape cache was cleared while it was building a new one. In #37, this caused a `NullPointerException` when the `PartContainer` attempted to union the, now `null`, incomplete culling shape cache with a part's culling shape.

This PR fixes the threading issue by doing two things: first, this changes the cache building functions to deal with local `VoxelShape`s instead of the `PartContainer`'s global ones; second, this changes `PartContainer` to keep its cached shapes in `AtomicReference`s, allowing them to be safely read and modified by multiple threads, even on architectures where 32-bit simple operations are not necessarily atomic, like ARM.

# Testing
This PR was quickly run in an environment with VanillaParts and WiredRedstone. Due to the nature of this issue, it is not really possible to easily reproduce and therefore not easy to test if this PR actually fixes it.

# Related Issues
This PR fixes #37