### PR TITLE
Shape cache threading fix 2

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
@@ -133,6 +133,13 @@ public class MultipartBlock extends Block
 
     @Override
     public VoxelShape getCollisionShape(BlockState state, BlockView view, BlockPos pos, ShapeContext ctx) {
+        if (view instanceof RenderAttachedBlockView renderView) {
+            Object data = renderView.getBlockEntityRenderAttachment(pos);
+            if (data instanceof PartModelData partData) {
+                return partData.collisionShape;
+            }
+        }
+
         BlockEntity be = view.getBlockEntity(pos);
         if (be instanceof MultipartBlockEntity) {
             MultipartBlockEntity container = (MultipartBlockEntity) be;
@@ -143,6 +150,13 @@ public class MultipartBlock extends Block
 
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView view, BlockPos pos, ShapeContext ctx) {
+        if (view instanceof RenderAttachedBlockView renderView) {
+            Object data = renderView.getBlockEntityRenderAttachment(pos);
+            if (data instanceof PartModelData partData) {
+                return partData.outlineShape;
+            }
+        }
+
         BlockEntity be = view.getBlockEntity(pos);
         if (be instanceof MultipartBlockEntity) {
             return ((MultipartBlockEntity) be).container.getOutlineShape();

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
@@ -141,8 +141,7 @@ public class MultipartBlock extends Block
         }
 
         BlockEntity be = view.getBlockEntity(pos);
-        if (be instanceof MultipartBlockEntity) {
-            MultipartBlockEntity container = (MultipartBlockEntity) be;
+        if (be instanceof MultipartBlockEntity container) {
             return container.container.getCollisionShape();
         }
         return VoxelShapes.empty();
@@ -158,23 +157,23 @@ public class MultipartBlock extends Block
         }
 
         BlockEntity be = view.getBlockEntity(pos);
-        if (be instanceof MultipartBlockEntity) {
-            return ((MultipartBlockEntity) be).container.getOutlineShape();
+        if (be instanceof MultipartBlockEntity container) {
+            return container.container.getOutlineShape();
         }
         return VoxelShapes.empty();
     }
 
     @Override
     public VoxelShape getCullingShape(BlockState state, BlockView view, BlockPos pos) {
-        BlockEntity be = view.getBlockEntity(pos);
         if (view instanceof RenderAttachedBlockView renderView) {
             Object data = renderView.getBlockEntityRenderAttachment(pos);
             if (data instanceof PartModelData partData) {
-                return ((PartModelData) data).cullingShape;
+                return partData.cullingShape;
             }
         }
-        if (be instanceof MultipartBlockEntity) {
-            MultipartBlockEntity container = (MultipartBlockEntity) be;
+
+        BlockEntity be = view.getBlockEntity(pos);
+        if (be instanceof MultipartBlockEntity container) {
             return container.container.getCullingShape();
         }
         return super.getCullingShape(state, view, pos);

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
@@ -208,7 +208,8 @@ public class MultipartBlockEntity extends BlockEntity
         ImmutableList<PartModelKey> built = list.build();
         // Refresh this, just to be on the safe side.
         container.partModelKeys = built;
-        return new PartModelData(container.getCullingShape(), built);
+        return new PartModelData(container.getCullingShape(), container.getCollisionShape(),
+                container.getOutlineShape(), built);
     }
 
     // Events

--- a/src/main/java/alexiil/mc/lib/multipart/impl/client/PartModelData.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/client/PartModelData.java
@@ -16,10 +16,14 @@ import alexiil.mc.lib.multipart.api.render.PartModelKey;
 public final class PartModelData {
 
     public final VoxelShape cullingShape;
+    public final VoxelShape collisionShape;
+    public final VoxelShape outlineShape;
     public final ImmutableList<PartModelKey> keys;
 
-    public PartModelData(VoxelShape cullingShape, ImmutableList<PartModelKey> keys) {
+    public PartModelData(VoxelShape cullingShape, VoxelShape collisionShape, VoxelShape outlineShape, ImmutableList<PartModelKey> keys) {
         this.cullingShape = cullingShape;
+        this.collisionShape = collisionShape;
+        this.outlineShape = outlineShape;
         this.keys = keys;
     }
 }


### PR DESCRIPTION
# This PR
This pull-request adds multi-part blocks' collision and outline shapes to the thread-safe, render-attachment data currently used for culling shapes and part-model keys.

# Testing
I have been testing this build in my dev-environment and have not run into any of the concurrency issues surrounding collision and outline shapes being accessed from multiple threads. In 0.7.3-pre.1, I was running into these issues quite frequently, so it is likely these issues have been fixed. However, due to the nature of these issues as concurrency-related, it is hard to make completely sure that they have been fixed.

# Related Issues
This pr fixes #48.
