### PR TITLE
Get running on 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,13 +90,7 @@ tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
+java.withSourcesJar()
 
 publishing {
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# Gradle keeps running out of heap space
+org.gradle.jvmargs=-Xmx1G
+
 minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.13.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 
 minecraft_version=1.19
 yarn_mappings=1.19+build.4
-loader_version=0.13.3
+loader_version=0.14.6
 fabric_version=0.55.3+1.19
 
 libblockattributes_version=0.11.0-pre.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -130,12 +130,6 @@ public class PartContainer implements MultipartContainer {
             @Override
             protected AbstractPart readContext(NetByteBuf buffer, IMsgReadCtx ctx, PartContainer parentValue)
                 throws InvalidInputDataException {
-
-                if (!parentValue.hasInitialisedFromRemote) {
-                    ctx.drop("This MultiPartBlock [" + parentValue.getMultipartPos().toShortString() + "] hasn't initialised from the server yet!");
-                    return null;
-                }
-
                 int index = buffer.readUnsignedByte();
                 List<PartHolder> parts = parentValue.parts;
                 if (index >= parts.size()) {

--- a/src/main/java/alexiil/mc/lib/multipart/mixin/impl/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/alexiil/mc/lib/multipart/mixin/impl/ClientPlayerInteractionManagerMixin.java
@@ -65,7 +65,7 @@ public class ClientPlayerInteractionManagerMixin implements IClientPlayerInterac
         at = @At(value = "INVOKE",
             target = "Lnet/minecraft/block/BlockState;onBlockBreakStart(Lnet/minecraft/world/World;"
                 + "Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;)V"),
-        method = "attackBlock(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;)Z")
+        method = "method_41930")
     void onBlockBreakStart(BlockState state, World world, BlockPos pos, PlayerEntity player) {
         if (LibMultiPart.DEBUG) {
             LibMultiPart.LOGGER.info("[player-interaction] onBlockBreakStart( " + pos + " " + state + " )");
@@ -83,7 +83,7 @@ public class ClientPlayerInteractionManagerMixin implements IClientPlayerInterac
         at = @At(
             value = "INVOKE", target = "Lnet/minecraft/block/BlockState;calcBlockBreakingDelta(Lnet/minecraft/entity/player/PlayerEntity;"
                 + "Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)F"
-        ), method = "attackBlock(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;)Z"
+        ), method = "method_41930"
     )
     float calcBlockBreakingDeltaAttack(BlockState state, PlayerEntity pl, BlockView view, BlockPos pos) {
         if (LibMultiPart.DEBUG) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
     ]
   },
   "depends": {
-    "minecraft": [ ">=1.18-rc.3 <1.19-" ],
+    "minecraft": [ ">=1.19- <1.20-" ],
     "fabricloader": ">=0.4.0",
     "fabric": "*",
     "libblockattributes_core": "*",

--- a/src/main/resources/libmultipart.common.json
+++ b/src/main/resources/libmultipart.common.json
@@ -3,7 +3,6 @@
   "package": "alexiil.mc.lib.multipart.mixin.impl",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "BlockSoundGroupAccessor",
     "LivingEntityMixin",
     "LootContextTypesAccessor",
     "ServerPlayerInteractionManagerMixin"


### PR DESCRIPTION
# This PR
This pull-request makes changes that allow LMP to run in Minecraft 1.19, as well as fixing some simple loom warnings. This PR also fixes a bug introduced during blanket-con that makes multipart parts unusable after they've been placed until they're reloaded.

# Testing
I have made sure the game can run and create a new world in 1.19.

I have also tested this as a dependency of 1.19 builds of Wired Redstone and SimplePipes, testing simple features of both mods in game.

# Notes
* Version numbers have not been updated.
* This depends on the version of LBA referenced in the PR: https://github.com/AlexIIL/LibBlockAttributes/pull/49#issue-1292039433