### PR TITLE
Remove hasInitializedFromRemote check in NET_KEY_PART reader

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -131,12 +131,6 @@ public class PartContainer implements MultipartContainer {
             @Override
             protected AbstractPart readContext(NetByteBuf buffer, IMsgReadCtx ctx, PartContainer parentValue)
                 throws InvalidInputDataException {
-
-                if (!parentValue.hasInitialisedFromRemote) {
-                    ctx.drop("This MultiPartBlock [" + parentValue.getMultipartPos().toShortString() + "] hasn't initialised from the server yet!");
-                    return null;
-                }
-
                 int index = buffer.readUnsignedByte();
                 List<PartHolder> parts = parentValue.parts;
                 if (index >= parts.size()) {


### PR DESCRIPTION
# This PR
This PR removes the erroneous `hasInitializedFromRemote` check in the `NET_KEY_PART` decoder so that clients who've had their `PartContainer`s initialized via part placement can still receive `NET_KEY_PART` packets.

# Testing
~~This change has not been tested specifically on this branch,~~ but has been tested in the `0.8.x-1.19.x` branch and has yielded the desired results. This is merely copying the change back to the `0.7.x-1.18.x` branch. I have tested the change on this branch and verified that it indeed does fix the issue where new part data was not getting sent to the client.

# Associated Issues
This PR fixes #56.