### PR TITLE
Add rotation/mirroring/transformation support

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
@@ -741,25 +741,14 @@ public abstract class AbstractPart {
         return ActionResult.PASS;
     }
 
-    /** Called when about to perform a transformation to see if this part can actually be transformed by the given
-     * transformation.
-     * <p>
-     * A transformation is only applied if all parts in the block return true from this method for the given
-     * transformation.
-     *
-     * @param transformation The transformation that would be applied.
-     * @return <code>true</code> if this transformation is something this part can be transformed by, <code>false</code>
-     * otherwise. */
-    public boolean canTransform(DirectionTransformation transformation) {
-        return true;
-    }
-
     /** Called whenever {@link BlockEntity#applyRotation(BlockRotation)} or {@link BlockState#rotate(BlockRotation)} is
      * called on the containing block.
      * <p>
      * Note: This is only called when an applied transformation consists solely of a rotate transformation.
      *
-     * @param rotation A rotation. LMP never calls this with {@link BlockRotation#NONE} */
+     * @param rotation A rotation. LMP never calls this with {@link BlockRotation#NONE}
+     * @deprecated Please use the {@link alexiil.mc.lib.multipart.api.event.PartTransformEvent.Rotate} event instead. */
+    @Deprecated
     public void rotate(BlockRotation rotation) {
 
     }
@@ -769,34 +758,10 @@ public abstract class AbstractPart {
      * <p>
      * Note: This is only called when an applied transformation consists solely of a mirror transformation.
      *
-     * @param mirror A mirror. LMP never calls this with {@link BlockMirror#NONE} */
+     * @param mirror A mirror. LMP never calls this with {@link BlockMirror#NONE}
+     * @deprecated Please use the {@link alexiil.mc.lib.multipart.api.event.PartTransformEvent.Mirror} event instead. */
+    @Deprecated
     public void mirror(BlockMirror mirror) {
-
-    }
-
-    /** Called whenever a transformation (e.g. rotation, mirror, etc.) has been applied to this part's block.
-     * <p>
-     * Transformations can be applied to this part's block via the {@link BlockState#mirror(BlockMirror)},
-     * {@link BlockState#rotate(BlockRotation)},
-     * {@link BlockEntity#applyRotation(BlockRotation)},
-     * {@link BlockEntity#applyMirror(BlockMirror)},
-     * {@link BlockEntity#applyTransformation(DirectionTransformation)}.
-     * <p>
-     * Note: Only this method <b>or</b> the {@link #rotate(BlockRotation)}/{@link #mirror(BlockMirror)} pair should be
-     * implemented, as these methods will generally be called with duplicate events.
-     *
-     * @param transformation An arbitrary axis-aligned transformation. */
-    public void transform(DirectionTransformation transformation) {
-
-    }
-
-    /** Called before any kind of transformation (e.g. rotation, mirror, etc.). */
-    public void preTransform() {
-
-    }
-
-    /** Called after any kind of transformation (e.g. rotation, mirror, etc.). */
-    public void postTransform() {
 
     }
 

--- a/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
@@ -741,6 +741,19 @@ public abstract class AbstractPart {
         return ActionResult.PASS;
     }
 
+    /** Called when about to perform a transformation to see if this part can actually be transformed by the given
+     * transformation.
+     * <p>
+     * A transformation is only applied if all parts in the block return true from this method for the given
+     * transformation.
+     *
+     * @param transformation The transformation that would be applied.
+     * @return <code>true</code> if this transformation is something this part can be transformed by, <code>false</code>
+     * otherwise. */
+    public boolean canTransform(DirectionTransformation transformation) {
+        return true;
+    }
+
     /** Called whenever {@link BlockEntity#applyRotation(BlockRotation)} or {@link BlockState#rotate(BlockRotation)} is
      * called on the containing block.
      * <p>

--- a/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
@@ -43,12 +43,8 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
-import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.*;
 import net.minecraft.util.math.Direction.AxisDirection;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
@@ -745,17 +741,49 @@ public abstract class AbstractPart {
         return ActionResult.PASS;
     }
 
-    /** Called whenever {@link BlockEntity#applyRotation(BlockRotation)} is called on the containing block.
+    /** Called whenever {@link BlockEntity#applyRotation(BlockRotation)} or {@link BlockState#rotate(BlockRotation)} is
+     * called on the containing block.
+     * <p>
+     * Note: This is only called when an applied transformation consists solely of a rotate transformation.
      *
      * @param rotation A rotation. LMP never calls this with {@link BlockRotation#NONE} */
     public void rotate(BlockRotation rotation) {
 
     }
 
-    /** Called whenever {@link BlockEntity#applyMirror(BlockMirror)} is called on the containing block.
+    /** Called whenever {@link BlockEntity#applyMirror(BlockMirror)} or {@link BlockState#mirror(BlockMirror)} is called
+     * on the containing block.
+     * <p>
+     * Note: This is only called when an applied transformation consists solely of a mirror transformation.
      *
      * @param mirror A mirror. LMP never calls this with {@link BlockMirror#NONE} */
     public void mirror(BlockMirror mirror) {
+
+    }
+
+    /** Called whenever a transformation (e.g. rotation, mirror, etc.) has been applied to this part's block.
+     * <p>
+     * Transformations can be applied to this part's block via the {@link BlockState#mirror(BlockMirror)},
+     * {@link BlockState#rotate(BlockRotation)},
+     * {@link BlockEntity#applyRotation(BlockRotation)},
+     * {@link BlockEntity#applyMirror(BlockMirror)},
+     * {@link BlockEntity#applyTransformation(DirectionTransformation)}.
+     * <p>
+     * Note: Only this method <b>or</b> the {@link #rotate(BlockRotation)}/{@link #mirror(BlockMirror)} pair should be
+     * implemented, as these methods will generally be called with duplicate events.
+     *
+     * @param transformation An arbitrary axis-aligned transformation. */
+    public void transform(DirectionTransformation transformation) {
+
+    }
+
+    /** Called before any kind of transformation (e.g. rotation, mirror, etc.). */
+    public void preTransform() {
+
+    }
+
+    /** Called after any kind of transformation (e.g. rotation, mirror, etc.). */
+    public void postTransform() {
 
     }
 

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartPostTransformEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartPostTransformEvent.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+/** Fired after all parts are transformed.
+ *
+ * @see PartTransformEvent */
+public final class PartPostTransformEvent extends MultipartEvent implements ContextlessEvent {
+    public static final PartPostTransformEvent INSTANCE = new PartPostTransformEvent();
+
+    private PartPostTransformEvent() {
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartPreTransformEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartPreTransformEvent.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+/** Fired before any parts are transformed.
+ *
+ * @see PartTransformEvent */
+public final class PartPreTransformEvent extends MultipartEvent implements ContextlessEvent {
+    public static final PartPreTransformEvent INSTANCE = new PartPreTransformEvent();
+
+    private PartPreTransformEvent() {
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformCheckEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformCheckEvent.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
+import net.minecraft.util.math.DirectionTransformation;
+
+/** Used to check if all parts in a multipart block support a type of transformation.
+ * <p>
+ * If any parts mark the given transformation as invalid, then the given transformation will not be applied to any part
+ * in the multipart block.
+ *
+ * @see PartTransformEvent */
+public class PartTransformCheckEvent extends MultipartEvent {
+    public final DirectionTransformation transformation;
+
+    private boolean invalid = false;
+
+    public PartTransformCheckEvent(DirectionTransformation transformation) {
+        this.transformation = transformation;
+    }
+
+    /** Returns whether a part has already marked this transformation as invalid. */
+    public boolean isInvalid() {
+        return invalid;
+    }
+
+    /** Marks this transformation as invalid.
+     * <p>
+     * If any parts mark the given transformation as invalid, then the given transformation will not be applied to any
+     * part in the multipart block. */
+    public void markInvalid() {
+        invalid = true;
+    }
+
+    /** Marks this transformation as invalid if it cannot be represented as a {@link net.minecraft.util.BlockRotation}
+     * or {@link net.minecraft.util.BlockMirror}. */
+    public void allowOnlyRotationOrMirror() {
+        invalid = invalid || !DirectionTransformationUtil.isRotationOrMirror(transformation);
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformEvent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.math.DirectionTransformation;
+
+/** Indicates that the given part, along with all other parts in the multipart block, are being transformed by the given
+ * transformation.
+ * <p>
+ * This transformation can represent any kind of axis-aligned rotation or mirror, not being confined to just
+ * {@link BlockRotation} or {@link BlockMirror} which have no effect on the y-axis. However, there are sub-events for
+ * when the transformation is specifically equivalent to either a {@link BlockRotation} or a {@link BlockMirror}.
+ * <p>
+ * Transformations can be applied to this part's block via
+ * {@link net.minecraft.block.BlockState#mirror(BlockMirror)},
+ * {@link net.minecraft.block.BlockState#rotate(BlockRotation)},
+ * {@link net.minecraft.block.entity.BlockEntity#applyRotation(BlockRotation)},
+ * {@link net.minecraft.block.entity.BlockEntity#applyMirror(BlockMirror)},
+ * {@link net.minecraft.block.entity.BlockEntity#applyTransformation(DirectionTransformation)}.
+ *
+ * @see PartTransformCheckEvent
+ * @see PartPreTransformEvent
+ * @see PartPostTransformEvent
+ * @see DirectionTransformationUtil */
+public class PartTransformEvent extends MultipartEvent {
+    public final DirectionTransformation transformation;
+
+    private PartTransformEvent(DirectionTransformation transformation) {
+        this.transformation = transformation;
+    }
+
+    /** Represents a transformation event for only a simple {@link BlockRotation}.
+     *
+     * @see PartTransformEvent */
+    public static class Rotate extends PartTransformEvent {
+        public final BlockRotation rotation;
+
+        private Rotate(BlockRotation rotation) {
+            super(rotation.getDirectionTransformation());
+            this.rotation = rotation;
+        }
+    }
+
+    /** Represents a transformation event for only a simple {@link BlockMirror}.
+     *
+     * @see PartTransformEvent */
+    public static class Mirror extends PartTransformEvent {
+        public final BlockMirror mirror;
+
+        private Mirror(BlockMirror mirror) {
+            super(mirror.getDirectionTransformation());
+            this.mirror = mirror;
+        }
+    }
+
+    /** Constructs the correct subclass for the given transformation.
+     * <p>
+     * If the given transformation can be represented as an equivalent {@link BlockRotation}, then a {@link Rotate}
+     * event is returned. If the given transformation can be represented as an equivalent {@link BlockMirror}, then a
+     * {@link Mirror} event is returned. If the given transformation cannot be represented as either a
+     * {@link BlockRotation} or a {@link BlockMirror} then only a base {@link PartTransformEvent} is returned. */
+    public static PartTransformEvent create(DirectionTransformation transformation) {
+        if (transformation == DirectionTransformation.IDENTITY) {
+            throw new IllegalArgumentException("A PartTransformEvent for an IDENTITY transformation is useless");
+        }
+
+        BlockRotation rotation = DirectionTransformationUtil.getRotation(transformation);
+        BlockMirror mirror = DirectionTransformationUtil.getMirror(transformation);
+
+        if (rotation != null) {
+            return new Rotate(rotation);
+        } else if (mirror != null) {
+            return new Mirror(mirror);
+        } else {
+            return new PartTransformEvent(transformation);
+        }
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/misc/DirectionTransformationUtil.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/misc/DirectionTransformationUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.misc;
+
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.math.DirectionTransformation;
+
+import javax.annotation.Nullable;
+
+/** A handful of utilities for working with {@link DirectionTransformation}s. */
+public final class DirectionTransformationUtil {
+    private DirectionTransformationUtil() {
+    }
+
+    /** Gets the equivalent {@link BlockRotation} for a given {@link DirectionTransformation} if any.
+     *
+     * @param transformation The transformation to try and turn into a BlockRotation.
+     * @return The BlockRotation equivalent to the given transformation or <code>null</code> if the given transformation
+     * has no equivalent BlockRotation. */
+    @Nullable
+    public static BlockRotation getRotation(DirectionTransformation transformation) {
+        return switch (transformation) {
+            case IDENTITY -> BlockRotation.NONE;
+            case ROT_90_Y_NEG -> BlockRotation.CLOCKWISE_90;
+            case ROT_180_FACE_XZ -> BlockRotation.CLOCKWISE_180;
+            case ROT_90_Y_POS -> BlockRotation.COUNTERCLOCKWISE_90;
+            default -> null;
+        };
+    }
+
+    /** Gets the equivalent {@link BlockMirror} for a given {@link DirectionTransformation} if any.
+     *
+     * @param transformation The transformation to try and turn into a BlockMirror.
+     * @return The BlockMirror equivalent to the given transformation or <code>null</code> if the given transformation
+     * has no equivalent BlockMirror. */
+    @Nullable
+    public static BlockMirror getMirror(DirectionTransformation transformation) {
+        // Note: BlockMirror.LEFT_RIGHT corresponds to DirectionTransformation.INVERT_Z and BlockMirror.FRONT_BACK
+        // corresponds to DirectionTransformation.INVERT_X. This is NOT intuitive.
+        return switch (transformation) {
+            case IDENTITY -> BlockMirror.NONE;
+            case INVERT_Z -> BlockMirror.LEFT_RIGHT;
+            case INVERT_X -> BlockMirror.FRONT_BACK;
+            default -> null;
+        };
+    }
+
+    /** Determines whether a {@link DirectionTransformation} can be represented as either a {@link BlockRotation} or
+     * {@link BlockMirror}. */
+    public static boolean isRotationOrMirror(DirectionTransformation transformation) {
+        return switch (transformation) {
+            case IDENTITY, ROT_90_Y_NEG, ROT_180_FACE_XZ, ROT_90_Y_POS, INVERT_Z, INVERT_X -> true;
+            default -> false;
+        };
+    }
+
+    /** Gets the relative transformation that would need to be prepended to the base transformation to obtain the new
+     * transformation.
+     *
+     * @param base The transformation we're relativizing the new transformation in relation to.
+     * @param newTransformation The transformation we're turning into a relative transformation.
+     * @return A relative transformation that could be prepended to <code>base</code> to obtain
+     * <code>newTransformation</code>. */
+    public static DirectionTransformation getRelativeTransformation(DirectionTransformation base, DirectionTransformation newTransformation) {
+        // 'A': the `base` transformation
+        // 'X': delta transformation prepended to the base to obtain new `newTransformation`
+        // 'A^-1': A.inverse()
+        //
+        // Currently `newTransformation` hold the value 'XA' but we really only want to find X.
+        // To find X, we just prepend the `newTransformation` to 'A^-1' to get: 'XAA^-1' = 'X'.
+        return base.inverse().prepend(newTransformation);
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
@@ -83,13 +83,15 @@ public class MultipartBlock extends Block
     public static final IntProperty LUMINANCE = IntProperty.of("luminance", 0, 15);
     public static final BooleanProperty EMITS_REDSTONE = BooleanProperty.of("emits_redstone");
 
-    /** BlockState-side transformation property, used for detecting when the BlockState has been transformed without the
+    /** BlockState-side transformation property used for detecting when the BlockState has been transformed without the
      * MultipartBlockEntity being involved.
      * <p>
      * The actual value of this property is meaningless. Only the difference between this and the block-entity's cached
-     * transformation is meaningful. And even then, a difference only means that the block-entity should call its
-     * parts' appropriate transformation methods when it gets the chance. A part's orientation and transformation
-     * should *always* be stored in the part itself. */
+     * transformation is meaningful. And even then, a difference only means that the block-entity should fire the
+     * appropriate transformation events when it gets the chance. A part's orientation and transformation should
+     * *always* be stored in the part itself.
+     *
+     * @see alexiil.mc.lib.multipart.api.event.PartTransformEvent */
     public static final EnumProperty<DirectionTransformation> TRANSFORMATION = EnumProperty.of("transformation", DirectionTransformation.class);
 
     public MultipartBlock(Settings settings) {

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
@@ -40,6 +40,7 @@ import net.minecraft.loot.context.LootContextTypes;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.IntProperty;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.ActionResult;
@@ -49,10 +50,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.*;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
@@ -84,6 +82,7 @@ public class MultipartBlock extends Block
 
     public static final IntProperty LUMINANCE = IntProperty.of("luminance", 0, 15);
     public static final BooleanProperty EMITS_REDSTONE = BooleanProperty.of("emits_redstone");
+    public static final EnumProperty<DirectionTransformation> TRANSFORMATION = EnumProperty.of("transformation", DirectionTransformation.class);
 
     public MultipartBlock(Settings settings) {
         super(settings);
@@ -92,6 +91,7 @@ public class MultipartBlock extends Block
                 .with(LUMINANCE, 0)//
                 .with(EMITS_REDSTONE, false)//
                 .with(Properties.WATERLOGGED, false)//
+                .with(TRANSFORMATION, DirectionTransformation.IDENTITY)//
         );
     }
 
@@ -104,7 +104,7 @@ public class MultipartBlock extends Block
     @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
         super.appendProperties(builder);
-        builder.add(LUMINANCE, EMITS_REDSTONE, Properties.WATERLOGGED);
+        builder.add(LUMINANCE, EMITS_REDSTONE, Properties.WATERLOGGED, TRANSFORMATION);
     }
 
     @Override
@@ -121,14 +121,12 @@ public class MultipartBlock extends Block
 
     @Override
     public BlockState rotate(BlockState state, BlockRotation rotation) {
-        // This is really just a TODO for the block entity.rotate method
-        throw new UnsupportedOperationException("Need BlockEntity.rotate too pls mojang");
+        return state.with(TRANSFORMATION, state.get(TRANSFORMATION).prepend(rotation.getDirectionTransformation()));
     }
 
     @Override
     public BlockState mirror(BlockState state, BlockMirror mirror) {
-        // This is really just a TODO for the block entity.mirror method
-        throw new UnsupportedOperationException("Need BlockEntity.mirror too pls mojang");
+        return state.with(TRANSFORMATION, state.get(TRANSFORMATION).prepend(mirror.getDirectionTransformation()));
     }
 
     @Override

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlock.java
@@ -82,6 +82,14 @@ public class MultipartBlock extends Block
 
     public static final IntProperty LUMINANCE = IntProperty.of("luminance", 0, 15);
     public static final BooleanProperty EMITS_REDSTONE = BooleanProperty.of("emits_redstone");
+
+    /** BlockState-side transformation property, used for detecting when the BlockState has been transformed without the
+     * MultipartBlockEntity being involved.
+     * <p>
+     * The actual value of this property is meaningless. Only the difference between this and the block-entity's cached
+     * transformation is meaningful. And even then, a difference only means that the block-entity should call its
+     * parts' appropriate transformation methods when it gets the chance. A part's orientation and transformation
+     * should *always* be stored in the part itself. */
     public static final EnumProperty<DirectionTransformation> TRANSFORMATION = EnumProperty.of("transformation", DirectionTransformation.class);
 
     public MultipartBlock(Settings settings) {

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
@@ -65,7 +65,7 @@ public class MultipartBlockEntity extends BlockEntity
 
     public MultipartBlockEntity(BlockPos pos, BlockState state) {
         super(LibMultiPart.BLOCK_ENTITY, pos, state);
-        container = new PartContainer(this, state.get(MultipartBlock.TRANSFORMATION));
+        container = new PartContainer(this, state.isOf(LibMultiPart.BLOCK) ? state.get(MultipartBlock.TRANSFORMATION) : DirectionTransformation.IDENTITY);
     }
 
     MultipartBlockEntity(PartContainer from, BlockPos pos, BlockState state) {

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
@@ -26,6 +26,7 @@ import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.DirectionTransformation;
 import net.minecraft.world.World;
 
 import alexiil.mc.lib.net.NetIdDataK;
@@ -102,6 +103,18 @@ public class MultipartBlockEntity extends BlockEntity
         if (mirror != BlockMirror.NONE) {
             container.mirror(mirror);
         }
+    }
+
+    public void applyTransformation(DirectionTransformation transformation) {
+        if (transformation != DirectionTransformation.IDENTITY) {
+            container.transform(transformation);
+        }
+    }
+
+    @Override
+    public void setCachedState(BlockState state) {
+        super.setCachedState(state);
+        container.setCachedState(state);
     }
 
     @Nonnull

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
@@ -65,7 +65,7 @@ public class MultipartBlockEntity extends BlockEntity
 
     public MultipartBlockEntity(BlockPos pos, BlockState state) {
         super(LibMultiPart.BLOCK_ENTITY, pos, state);
-        container = new PartContainer(this);
+        container = new PartContainer(this, state.get(MultipartBlock.TRANSFORMATION));
     }
 
     MultipartBlockEntity(PartContainer from, BlockPos pos, BlockState state) {

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartUtilImpl.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartUtilImpl.java
@@ -18,6 +18,7 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.DirectionTransformation;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
@@ -119,7 +120,7 @@ public final class MultipartUtilImpl {
 
         MultipartBlockEntity be = new MultipartBlockEntity(pos, state);
         be.setWorld(world);
-        PartContainer container = new PartContainer(be);
+        PartContainer container = new PartContainer(be, DirectionTransformation.IDENTITY);
         PartHolder holder = new PartHolder(container, creator);
         VoxelShape shape = holder.part.getCollisionShape();
 
@@ -157,7 +158,7 @@ public final class MultipartUtilImpl {
             pos, LibMultiPart.BLOCK.getDefaultState().with(Properties.WATERLOGGED, hasWater)
         );
         be.setWorld(world);
-        PartContainer container = new PartContainer(be);
+        PartContainer container = new PartContainer(be, DirectionTransformation.IDENTITY);
 
         List<PartHolder> existingHolders = new ArrayList<>();
         for (MultipartCreator creator : existing) {

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import alexiil.mc.lib.multipart.api.event.*;
-import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
 import com.google.common.collect.ImmutableList;
 
 import net.minecraft.block.Block;
@@ -61,7 +59,9 @@ import alexiil.mc.lib.multipart.api.AbstractPart;
 import alexiil.mc.lib.multipart.api.MultipartContainer;
 import alexiil.mc.lib.multipart.api.MultipartEventBus;
 import alexiil.mc.lib.multipart.api.MultipartHolder;
+import alexiil.mc.lib.multipart.api.event.*;
 import alexiil.mc.lib.multipart.api.event.PartRedstonePowerEvent.PartRedstonePowerEventFactory;
+import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties.RedstonePowerProperty;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties.StrongRedstonePowerProperty;
@@ -907,7 +907,7 @@ public class PartContainer implements MultipartContainer {
     }
 
     /** Checks if a transformation is valid for all parts in this container. */
-    boolean transformInvalid(DirectionTransformation transformation) {
+    boolean isTransformInvalid(DirectionTransformation transformation) {
         PartTransformCheckEvent event = new PartTransformCheckEvent(transformation);
         eventBus.fireEvent(event);
         return event.isInvalid();
@@ -915,7 +915,7 @@ public class PartContainer implements MultipartContainer {
 
     void rotate(BlockRotation rotation) {
         DirectionTransformation transformation = rotation.getDirectionTransformation();
-        if (transformInvalid(transformation)) {
+        if (isTransformInvalid(transformation)) {
             return;
         }
 
@@ -928,15 +928,14 @@ public class PartContainer implements MultipartContainer {
 
     private void callRotate(BlockRotation rotation) {
         for (PartHolder holder : parts) {
-            // This is always called in conjunction with #callTransform which performs the appropriate PosPartId
-            // transformations.
+            // Call the deprecated rotate method for backwards compatibility.
             holder.part.rotate(rotation);
         }
     }
 
     void mirror(BlockMirror mirror) {
         DirectionTransformation transformation = mirror.getDirectionTransformation();
-        if (transformInvalid(transformation)) {
+        if (isTransformInvalid(transformation)) {
             return;
         }
 
@@ -949,14 +948,13 @@ public class PartContainer implements MultipartContainer {
 
     private void callMirror(BlockMirror mirror) {
         for (PartHolder holder : parts) {
-            // This is always called in conjunction with #callTransform which performs the appropriate PosPartId
-            // transformations.
+            // Call the deprecated mirror method for backwards compatibility.
             holder.part.mirror(mirror);
         }
     }
 
     void transform(DirectionTransformation transformation) {
-        if (transformInvalid(transformation)) {
+        if (isTransformInvalid(transformation)) {
             return;
         }
 
@@ -999,7 +997,7 @@ public class PartContainer implements MultipartContainer {
             // The actual value of the blockstate transform is meaningless, only the difference between it and the
             // cached transform is used. This means we can just ignore invalid transformations without having to revert
             // the blockstate or anything.
-            if (transformInvalid(deltaTransform)) {
+            if (isTransformInvalid(deltaTransform)) {
                 return;
             }
 

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import alexiil.mc.lib.multipart.api.event.*;
+import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
 import com.google.common.collect.ImmutableList;
 
 import net.minecraft.block.Block;
@@ -59,13 +61,7 @@ import alexiil.mc.lib.multipart.api.AbstractPart;
 import alexiil.mc.lib.multipart.api.MultipartContainer;
 import alexiil.mc.lib.multipart.api.MultipartEventBus;
 import alexiil.mc.lib.multipart.api.MultipartHolder;
-import alexiil.mc.lib.multipart.api.event.PartAddedEvent;
-import alexiil.mc.lib.multipart.api.event.PartContainerState;
-import alexiil.mc.lib.multipart.api.event.PartOfferedEvent;
-import alexiil.mc.lib.multipart.api.event.PartRedstonePowerEvent;
 import alexiil.mc.lib.multipart.api.event.PartRedstonePowerEvent.PartRedstonePowerEventFactory;
-import alexiil.mc.lib.multipart.api.event.PartRemovedEvent;
-import alexiil.mc.lib.multipart.api.event.PartTickEvent;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties.RedstonePowerProperty;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties.StrongRedstonePowerProperty;
@@ -912,13 +908,9 @@ public class PartContainer implements MultipartContainer {
 
     /** Checks if a transformation is valid for all parts in this container. */
     boolean transformInvalid(DirectionTransformation transformation) {
-        for (PartHolder holder : parts) {
-            if (!holder.part.canTransform(transformation)) {
-                return true;
-            }
-        }
-
-        return false;
+        PartTransformCheckEvent event = new PartTransformCheckEvent(transformation);
+        eventBus.fireEvent(event);
+        return event.isInvalid();
     }
 
     void rotate(BlockRotation rotation) {
@@ -927,10 +919,11 @@ public class PartContainer implements MultipartContainer {
             return;
         }
 
-        callPreTransform();
+        eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
         callRotate(rotation);
-        callTransform(transformation);
-        callPostTransform();
+        eventBus.fireEvent(PartTransformEvent.create(transformation));
+        transformRequiredParts(transformation);
+        eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
     }
 
     private void callRotate(BlockRotation rotation) {
@@ -947,10 +940,11 @@ public class PartContainer implements MultipartContainer {
             return;
         }
 
-        callPreTransform();
+        eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
         callMirror(mirror);
-        callTransform(transformation);
-        callPostTransform();
+        eventBus.fireEvent(PartTransformEvent.create(transformation));
+        transformRequiredParts(transformation);
+        eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
     }
 
     private void callMirror(BlockMirror mirror) {
@@ -966,41 +960,28 @@ public class PartContainer implements MultipartContainer {
             return;
         }
 
-        callPreTransform();
+        eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
         tryCallSimplifiedTransform(transformation);
-        callTransform(transformation);
-        callPostTransform();
+        eventBus.fireEvent(PartTransformEvent.create(transformation));
+        transformRequiredParts(transformation);
+        eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
     }
 
-    private void callTransform(DirectionTransformation transformation) {
+    private void transformRequiredParts(DirectionTransformation transformation) {
         for (PartHolder holder : parts) {
-            holder.transform(transformation);
-        }
-    }
-
-    private void callPreTransform() {
-        for (PartHolder holder : parts) {
-            holder.part.preTransform();
-        }
-    }
-
-    private void callPostTransform() {
-        for (PartHolder holder : parts) {
-            holder.part.postTransform();
+            holder.transformRequiredParts(transformation);
         }
     }
 
     private void tryCallSimplifiedTransform(DirectionTransformation transformation) {
-        switch (transformation) {
-            case ROT_90_Y_NEG -> callRotate(BlockRotation.CLOCKWISE_90);
-            case ROT_180_FACE_XZ -> callRotate(BlockRotation.CLOCKWISE_180);
-            case ROT_90_Y_POS -> callRotate(BlockRotation.COUNTERCLOCKWISE_90);
-            // Why is BlockMirror like this? I guess LEFT_RIGHT means mirroring across a line from left to right?
-            case INVERT_Z -> callMirror(BlockMirror.LEFT_RIGHT);
-            case INVERT_X -> callMirror(BlockMirror.FRONT_BACK);
-            default -> {
-                // Do nothing with un-handleable values.
-            }
+        BlockRotation rotation = DirectionTransformationUtil.getRotation(transformation);
+        if (rotation != null) {
+            callRotate(rotation);
+        }
+
+        BlockMirror mirror = DirectionTransformationUtil.getMirror(transformation);
+        if (mirror != null) {
+            callMirror(mirror);
         }
     }
 
@@ -1012,13 +993,7 @@ public class PartContainer implements MultipartContainer {
 
     private void updateTransform(DirectionTransformation stateTransform) {
         if (stateTransform != cachedTransformation) {
-            // A: cached transformation
-            // X: delta transformation prepended to blockstate while we weren't looking
-            // A^-1: A.inverse()
-            //
-            // Currently the blockstate holds a transformation 'XA' but we really only want to find X.
-            // To find X, we just prepend the blockstate's transformation to A^-1 to get: XAA^-1 = X.
-            DirectionTransformation deltaTransform = cachedTransformation.inverse().prepend(stateTransform);
+            DirectionTransformation deltaTransform = DirectionTransformationUtil.getRelativeTransformation(cachedTransformation, stateTransform);
             cachedTransformation = stateTransform;
 
             // The actual value of the blockstate transform is meaningless, only the difference between it and the
@@ -1028,10 +1003,11 @@ public class PartContainer implements MultipartContainer {
                 return;
             }
 
-            callPreTransform();
+            eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
             tryCallSimplifiedTransform(deltaTransform);
-            callTransform(deltaTransform);
-            callPostTransform();
+            eventBus.fireEvent(PartTransformEvent.create(deltaTransform));
+            transformRequiredParts(deltaTransform);
+            eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
         }
     }
 

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -905,7 +905,6 @@ public class PartContainer implements MultipartContainer {
             return;
         }
 
-        transformBlockState(transformation);
         callPreTransform();
         callRotate(rotation);
         callTransform(transformation);
@@ -926,7 +925,6 @@ public class PartContainer implements MultipartContainer {
             return;
         }
 
-        transformBlockState(transformation);
         callPreTransform();
         callMirror(mirror);
         callTransform(transformation);
@@ -946,7 +944,6 @@ public class PartContainer implements MultipartContainer {
             return;
         }
 
-        transformBlockState(transformation);
         callPreTransform();
         tryCallSimplifiedTransform(transformation);
         callTransform(transformation);
@@ -983,18 +980,6 @@ public class PartContainer implements MultipartContainer {
                 // Do nothing with un-handleable values.
             }
         }
-    }
-
-    /** Applies a new transformation to this container's corresponding block's BlockState and then updates this
-     * container's cached transformation value to match. */
-    private void transformBlockState(DirectionTransformation transformation) {
-        World world = blockEntity.world();
-        BlockPos pos = blockEntity.getPos();
-        BlockState state = world.getBlockState(pos);
-        DirectionTransformation stateTransform = state.get(MultipartBlock.TRANSFORMATION);
-        DirectionTransformation newTransform = stateTransform.prepend(transformation);
-        cachedTransformation = newTransform;
-        world.setBlockState(pos, state.with(MultipartBlock.TRANSFORMATION, newTransform));
     }
 
     /** Used for tracking transformation changes and notifying contained parts if need be. */

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartHolder.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartHolder.java
@@ -35,7 +35,6 @@ import alexiil.mc.lib.net.InvalidInputDataException;
 import alexiil.mc.lib.net.NetByteBuf;
 
 import alexiil.mc.lib.multipart.api.AbstractPart;
-import alexiil.mc.lib.multipart.api.AbstractPart.ItemDropTarget;
 import alexiil.mc.lib.multipart.api.MultipartContainer;
 import alexiil.mc.lib.multipart.api.MultipartContainer.MultipartCreator;
 import alexiil.mc.lib.multipart.api.MultipartHolder;
@@ -410,8 +409,7 @@ public final class PartHolder implements MultipartHolder {
         assert requiredParts == null : "Required Parts (" + requiredParts + ") wasn't fully cleared!";
     }
 
-    void rotate(BlockRotation rotation) {
-        part.rotate(rotation);
+    void rotateRequiredParts(BlockRotation rotation) {
         unloadedRequiredParts = rotate(unloadedRequiredParts, rotation);
         unloadedInverseRequiredParts = rotate(unloadedInverseRequiredParts, rotation);
     }
@@ -427,8 +425,7 @@ public final class PartHolder implements MultipartHolder {
         return to;
     }
 
-    void mirror(BlockMirror mirror) {
-        part.mirror(mirror);
+    void mirrorRequiredParts(BlockMirror mirror) {
         unloadedRequiredParts = mirror(unloadedRequiredParts, mirror);
         unloadedInverseRequiredParts = mirror(unloadedInverseRequiredParts, mirror);
     }
@@ -444,8 +441,7 @@ public final class PartHolder implements MultipartHolder {
         return to;
     }
 
-    void transform(DirectionTransformation transformation) {
-        part.transform(transformation);
+    void transformRequiredParts(DirectionTransformation transformation) {
         unloadedRequiredParts = transform(unloadedRequiredParts, transformation);
         unloadedInverseRequiredParts = transform(unloadedInverseRequiredParts, transformation);
     }

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartHolder.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartHolder.java
@@ -26,6 +26,7 @@ import net.minecraft.util.BlockRotation;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.DirectionTransformation;
 import net.minecraft.util.math.Vec3d;
 
 import alexiil.mc.lib.net.IMsgReadCtx;
@@ -439,6 +440,23 @@ public final class PartHolder implements MultipartHolder {
         Set<PosPartId> to = identityHashSet();
         for (PosPartId pos : parts) {
             to.add(pos.mirror(container, mirror));
+        }
+        return to;
+    }
+
+    void transform(DirectionTransformation transformation) {
+        part.transform(transformation);
+        unloadedRequiredParts = transform(unloadedRequiredParts, transformation);
+        unloadedInverseRequiredParts = transform(unloadedInverseRequiredParts, transformation);
+    }
+
+    private Set<PosPartId> transform(Set<PosPartId> parts, DirectionTransformation transformation) {
+        if (parts == null) {
+            return null;
+        }
+        Set<PosPartId> to = identityHashSet();
+        for (PosPartId pos : parts) {
+            to.add(pos.transform(container, transformation));
         }
         return to;
     }

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
@@ -17,6 +17,8 @@ import net.minecraft.util.math.BlockPos;
 
 import alexiil.mc.lib.multipart.api.AbstractPart;
 import alexiil.mc.lib.multipart.api.MultipartHolder;
+import net.minecraft.util.math.DirectionTransformation;
+import net.minecraft.util.math.Vec3f;
 
 /** Combined {@link BlockPos} + {@link PartHolder#uniqueId}. */
 final class PosPartId {
@@ -118,5 +120,19 @@ final class PosPartId {
             z = -z;
         }
         return new PosPartId(new BlockPos(x + f.getX(), pos.getY(), z + f.getZ()), uid);
+    }
+
+    public PosPartId transform(PartContainer from, DirectionTransformation transformation) {
+        if (transformation == DirectionTransformation.IDENTITY) {
+            return this;
+        }
+
+        BlockPos f = from.getMultipartPos();
+
+        Vec3f relPos = new Vec3f(pos.getX() - f.getX(), pos.getY() - f.getY(), pos.getZ() - f.getZ());
+        relPos.transform(transformation.getMatrix());
+        BlockPos transformedPos = new BlockPos(Math.round(relPos.getX()), Math.round(relPos.getY()), Math.round(relPos.getZ()));
+
+        return new PosPartId(transformedPos.add(f), uid);
     }
 }

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
@@ -113,11 +113,14 @@ final class PosPartId {
         BlockPos f = from.getMultipartPos();
         int x = pos.getX() - f.getX();
         int z = pos.getZ() - f.getZ();
+
+        // For some reason, BlockMirror.LEFT_RIGHT corresponds to inverting the Z-axis and BlockMirror.FRONT_BACK
+        // corresponds to inverting the X-axis.
         if (mirror == BlockMirror.LEFT_RIGHT) {
-            x = -x;
+            z = -z;
         } else {
             assert mirror == BlockMirror.FRONT_BACK;
-            z = -z;
+            x = -x;
         }
         return new PosPartId(new BlockPos(x + f.getX(), pos.getY(), z + f.getZ()), uid);
     }


### PR DESCRIPTION
# This PR
This PR adds support for applying transformations to multipart blocks.

# Extra Features
This PR has support for:

* [x] Handling when one part in a container can't be rotated/transformed in a way the container wants to be transformed.
* [x] Handling when a transformation is applied to the BlockState before the BlockEntity has been created/loaded. There are some rare circumstances under which this can happen, like if a multipart-block happens to be missing its BlockEntity before it gets transformed.

# Testing
I have tested this PR with a build of WiredRedstone and found that it does correctly allow create contraptions to rotate the WiredRedstone parts.

# Associated
This PR is intended to fix #52, but fixing #57, #58, and #59 may also be required in order for this PR to be tested properly.