### PR TITLE
0.8.x-1.19.x Add rotation/mirroring/transformation support

### DIFF
--- a/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
@@ -746,16 +746,26 @@ public abstract class AbstractPart {
         return ActionResult.PASS;
     }
 
-    /** Called whenever {@link BlockEntity#applyRotation(BlockRotation)} is called on the containing block.
+    /** Called whenever {@link BlockEntity#applyRotation(BlockRotation)} or {@link BlockState#rotate(BlockRotation)} is
+     * called on the containing block.
+     * <p>
+     * Note: This is only called when an applied transformation consists solely of a rotate transformation.
      *
-     * @param rotation A rotation. LMP never calls this with {@link BlockRotation#NONE} */
+     * @param rotation A rotation. LMP never calls this with {@link BlockRotation#NONE}
+     * @deprecated Please use the {@link alexiil.mc.lib.multipart.api.event.PartTransformEvent.Rotate} event instead. */
+    @Deprecated
     public void rotate(BlockRotation rotation) {
 
     }
 
-    /** Called whenever {@link BlockEntity#applyMirror(BlockMirror)} is called on the containing block.
+    /** Called whenever {@link BlockEntity#applyMirror(BlockMirror)} or {@link BlockState#mirror(BlockMirror)} is called
+     * on the containing block.
+     * <p>
+     * Note: This is only called when an applied transformation consists solely of a mirror transformation.
      *
-     * @param mirror A mirror. LMP never calls this with {@link BlockMirror#NONE} */
+     * @param mirror A mirror. LMP never calls this with {@link BlockMirror#NONE}
+     * @deprecated Please use the {@link alexiil.mc.lib.multipart.api.event.PartTransformEvent.Mirror} event instead. */
+    @Deprecated
     public void mirror(BlockMirror mirror) {
 
     }

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartPostTransformEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartPostTransformEvent.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+/** Fired after all parts are transformed.
+ *
+ * @see PartTransformEvent */
+public final class PartPostTransformEvent extends MultipartEvent implements ContextlessEvent {
+    public static final PartPostTransformEvent INSTANCE = new PartPostTransformEvent();
+
+    private PartPostTransformEvent() {
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartPreTransformEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartPreTransformEvent.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+/** Fired before any parts are transformed.
+ *
+ * @see PartTransformEvent */
+public final class PartPreTransformEvent extends MultipartEvent implements ContextlessEvent {
+    public static final PartPreTransformEvent INSTANCE = new PartPreTransformEvent();
+
+    private PartPreTransformEvent() {
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformCheckEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformCheckEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+import net.minecraft.util.math.DirectionTransformation;
+
+import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
+
+/**
+ * Used to check if all parts in a multipart block support a type of transformation.
+ * <p>
+ * If any parts mark the given transformation as invalid, then the given transformation will not be applied to any part
+ * in the multipart block.
+ *
+ * @see PartTransformEvent
+ */
+public class PartTransformCheckEvent extends MultipartEvent {
+    public final DirectionTransformation transformation;
+
+    private boolean invalid = false;
+
+    public PartTransformCheckEvent(DirectionTransformation transformation) {
+        this.transformation = transformation;
+    }
+
+    /**
+     * Returns whether a part has already marked this transformation as invalid.
+     */
+    public boolean isInvalid() {
+        return invalid;
+    }
+
+    /**
+     * Marks this transformation as invalid.
+     * <p>
+     * If any parts mark the given transformation as invalid, then the given transformation will not be applied to any
+     * part in the multipart block.
+     */
+    public void markInvalid() {
+        invalid = true;
+    }
+
+    /**
+     * Marks this transformation as invalid if it cannot be represented as a {@link net.minecraft.util.BlockRotation}
+     * or {@link net.minecraft.util.BlockMirror}.
+     */
+    public void allowOnlyRotationOrMirror() {
+        invalid = invalid || !DirectionTransformationUtil.isRotationOrMirror(transformation);
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformEvent.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/event/PartTransformEvent.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.event;
+
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.math.DirectionTransformation;
+
+import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
+
+/**
+ * Indicates that the given part, along with all other parts in the multipart block, are being transformed by the given
+ * transformation.
+ * <p>
+ * This transformation can represent any kind of axis-aligned rotation or mirror, not being confined to just
+ * {@link BlockRotation} or {@link BlockMirror} which have no effect on the y-axis. However, there are sub-events for
+ * when the transformation is specifically equivalent to either a {@link BlockRotation} or a {@link BlockMirror}.
+ * <p>
+ * Transformations can be applied to this part's block via
+ * {@link net.minecraft.block.BlockState#mirror(BlockMirror)},
+ * {@link net.minecraft.block.BlockState#rotate(BlockRotation)},
+ * {@link net.minecraft.block.entity.BlockEntity#applyRotation(BlockRotation)},
+ * {@link net.minecraft.block.entity.BlockEntity#applyMirror(BlockMirror)},
+ * {@link net.minecraft.block.entity.BlockEntity#applyTransformation(DirectionTransformation)}.
+ *
+ * @see PartTransformCheckEvent
+ * @see PartPreTransformEvent
+ * @see PartPostTransformEvent
+ * @see DirectionTransformationUtil
+ */
+public class PartTransformEvent extends MultipartEvent {
+    public final DirectionTransformation transformation;
+
+    private PartTransformEvent(DirectionTransformation transformation) {
+        this.transformation = transformation;
+    }
+
+    /**
+     * Represents a transformation event for only a simple {@link BlockRotation}.
+     *
+     * @see PartTransformEvent
+     */
+    public static class Rotate extends PartTransformEvent {
+        public final BlockRotation rotation;
+
+        private Rotate(BlockRotation rotation) {
+            super(rotation.getDirectionTransformation());
+            this.rotation = rotation;
+        }
+    }
+
+    /**
+     * Represents a transformation event for only a simple {@link BlockMirror}.
+     *
+     * @see PartTransformEvent
+     */
+    public static class Mirror extends PartTransformEvent {
+        public final BlockMirror mirror;
+
+        private Mirror(BlockMirror mirror) {
+            super(mirror.getDirectionTransformation());
+            this.mirror = mirror;
+        }
+    }
+
+    /**
+     * Constructs the correct subclass for the given transformation.
+     * <p>
+     * If the given transformation can be represented as an equivalent {@link BlockRotation}, then a {@link Rotate}
+     * event is returned. If the given transformation can be represented as an equivalent {@link BlockMirror}, then a
+     * {@link Mirror} event is returned. If the given transformation cannot be represented as either a
+     * {@link BlockRotation} or a {@link BlockMirror} then only a base {@link PartTransformEvent} is returned.
+     */
+    public static PartTransformEvent create(DirectionTransformation transformation) {
+        if (transformation == DirectionTransformation.IDENTITY) {
+            throw new IllegalArgumentException("A PartTransformEvent for an IDENTITY transformation is useless");
+        }
+
+        BlockRotation rotation = DirectionTransformationUtil.getRotation(transformation);
+        BlockMirror mirror = DirectionTransformationUtil.getMirror(transformation);
+
+        if (rotation != null) {
+            return new Rotate(rotation);
+        } else if (mirror != null) {
+            return new Mirror(mirror);
+        } else {
+            return new PartTransformEvent(transformation);
+        }
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/api/misc/DirectionTransformationUtil.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/misc/DirectionTransformationUtil.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 AlexIIL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package alexiil.mc.lib.multipart.api.misc;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.math.DirectionTransformation;
+
+/**
+ * A handful of utilities for working with {@link DirectionTransformation}s.
+ */
+public final class DirectionTransformationUtil {
+    private DirectionTransformationUtil() {
+    }
+
+    /**
+     * Gets the equivalent {@link BlockRotation} for a given {@link DirectionTransformation} if any.
+     *
+     * @param transformation The transformation to try and turn into a BlockRotation.
+     * @return The BlockRotation equivalent to the given transformation or <code>null</code> if the given transformation
+     * has no equivalent BlockRotation.
+     */
+    @Nullable
+    public static BlockRotation getRotation(DirectionTransformation transformation) {
+        return switch (transformation) {
+            case IDENTITY -> BlockRotation.NONE;
+            case ROT_90_Y_NEG -> BlockRotation.CLOCKWISE_90;
+            case ROT_180_FACE_XZ -> BlockRotation.CLOCKWISE_180;
+            case ROT_90_Y_POS -> BlockRotation.COUNTERCLOCKWISE_90;
+            default -> null;
+        };
+    }
+
+    /**
+     * Gets the equivalent {@link BlockMirror} for a given {@link DirectionTransformation} if any.
+     *
+     * @param transformation The transformation to try and turn into a BlockMirror.
+     * @return The BlockMirror equivalent to the given transformation or <code>null</code> if the given transformation
+     * has no equivalent BlockMirror.
+     */
+    @Nullable
+    public static BlockMirror getMirror(DirectionTransformation transformation) {
+        // Note: BlockMirror.LEFT_RIGHT corresponds to DirectionTransformation.INVERT_Z and BlockMirror.FRONT_BACK
+        // corresponds to DirectionTransformation.INVERT_X. This is NOT intuitive.
+        return switch (transformation) {
+            case IDENTITY -> BlockMirror.NONE;
+            case INVERT_Z -> BlockMirror.LEFT_RIGHT;
+            case INVERT_X -> BlockMirror.FRONT_BACK;
+            default -> null;
+        };
+    }
+
+    /**
+     * Determines whether a {@link DirectionTransformation} can be represented as either a {@link BlockRotation} or
+     * {@link BlockMirror}.
+     */
+    public static boolean isRotationOrMirror(DirectionTransformation transformation) {
+        return switch (transformation) {
+            case IDENTITY, ROT_90_Y_NEG, ROT_180_FACE_XZ, ROT_90_Y_POS, INVERT_Z, INVERT_X -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * Gets the relative transformation that would need to be prepended to the base transformation to obtain the new
+     * transformation.
+     *
+     * @param base              The transformation we're relativizing the new transformation in relation to.
+     * @param newTransformation The transformation we're turning into a relative transformation.
+     * @return A relative transformation that could be prepended to <code>base</code> to obtain
+     * <code>newTransformation</code>.
+     */
+    public static DirectionTransformation getRelativeTransformation(DirectionTransformation base,
+                                                                    DirectionTransformation newTransformation) {
+        // 'A': the `base` transformation
+        // 'X': delta transformation prepended to the base to obtain new `newTransformation`
+        // 'A^-1': A.inverse()
+        //
+        // Currently `newTransformation` hold the value 'XA' but we really only want to find X.
+        // To find X, we just prepend the `newTransformation` to 'A^-1' to get: 'XAA^-1' = 'X'.
+        return base.inverse().prepend(newTransformation);
+    }
+}

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartBlockEntity.java
@@ -26,6 +26,7 @@ import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.DirectionTransformation;
 import net.minecraft.world.World;
 
 import alexiil.mc.lib.net.NetIdDataK;
@@ -64,7 +65,7 @@ public class MultipartBlockEntity extends BlockEntity
 
     public MultipartBlockEntity(BlockPos pos, BlockState state) {
         super(LibMultiPart.BLOCK_ENTITY, pos, state);
-        container = new PartContainer(this);
+        container = new PartContainer(this, state.isOf(LibMultiPart.BLOCK) ? state.get(MultipartBlock.TRANSFORMATION) : DirectionTransformation.IDENTITY);
     }
 
     MultipartBlockEntity(PartContainer from, BlockPos pos, BlockState state) {
@@ -102,6 +103,18 @@ public class MultipartBlockEntity extends BlockEntity
         if (mirror != BlockMirror.NONE) {
             container.mirror(mirror);
         }
+    }
+
+    public void applyTransformation(DirectionTransformation transformation) {
+        if (transformation != DirectionTransformation.IDENTITY) {
+            container.transform(transformation);
+        }
+    }
+
+    @Override
+    public void setCachedState(BlockState state) {
+        super.setCachedState(state);
+        container.setCachedState(state);
     }
 
     @Nonnull

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartUtilImpl.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartUtilImpl.java
@@ -18,6 +18,7 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.DirectionTransformation;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
@@ -119,7 +120,7 @@ public final class MultipartUtilImpl {
 
         MultipartBlockEntity be = new MultipartBlockEntity(pos, state);
         be.setWorld(world);
-        PartContainer container = new PartContainer(be);
+        PartContainer container = new PartContainer(be, DirectionTransformation.IDENTITY);
         PartHolder holder = new PartHolder(container, creator);
         VoxelShape shape = holder.part.getCollisionShape();
 
@@ -157,7 +158,7 @@ public final class MultipartUtilImpl {
             pos, LibMultiPart.BLOCK.getDefaultState().with(Properties.WATERLOGGED, hasWater)
         );
         be.setWorld(world);
-        PartContainer container = new PartContainer(be);
+        PartContainer container = new PartContainer(be, DirectionTransformation.IDENTITY);
 
         List<PartHolder> existingHolders = new ArrayList<>();
         for (MultipartCreator creator : existing) {

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartContainer.java
@@ -35,6 +35,7 @@ import net.minecraft.util.Util;
 import net.minecraft.util.function.BooleanBiFunction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.DirectionTransformation;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
@@ -60,10 +61,15 @@ import alexiil.mc.lib.multipart.api.MultipartHolder;
 import alexiil.mc.lib.multipart.api.event.PartAddedEvent;
 import alexiil.mc.lib.multipart.api.event.PartContainerState;
 import alexiil.mc.lib.multipart.api.event.PartOfferedEvent;
+import alexiil.mc.lib.multipart.api.event.PartPostTransformEvent;
+import alexiil.mc.lib.multipart.api.event.PartPreTransformEvent;
 import alexiil.mc.lib.multipart.api.event.PartRedstonePowerEvent;
 import alexiil.mc.lib.multipart.api.event.PartRedstonePowerEvent.PartRedstonePowerEventFactory;
 import alexiil.mc.lib.multipart.api.event.PartRemovedEvent;
 import alexiil.mc.lib.multipart.api.event.PartTickEvent;
+import alexiil.mc.lib.multipart.api.event.PartTransformCheckEvent;
+import alexiil.mc.lib.multipart.api.event.PartTransformEvent;
+import alexiil.mc.lib.multipart.api.misc.DirectionTransformationUtil;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties.RedstonePowerProperty;
 import alexiil.mc.lib.multipart.api.property.MultipartProperties.StrongRedstonePowerProperty;
@@ -165,6 +171,28 @@ public class PartContainer implements MultipartContainer {
     boolean havePropertiesChanged = false;
     boolean hasTicked = false;
 
+    /** Used by {@link #setCachedState(BlockState)} to determine how the BlockState's transformation has changed.
+     * <p>
+     * All other methods that apply a transformation to this part container should use the BlockState's transformation
+     * as the source-of-truth for what the current transformation is, and make sure to update this value when updating
+     * the BlockState's transformation. If this value is not updated when the BlockState's transformation is updated,
+     * then {@link #setCachedState(BlockState)} will think that the BlockState had been updated externally and will
+     * attempt to apply the transformation all over again. */
+    DirectionTransformation cachedTransformation = DirectionTransformation.IDENTITY;
+
+    /** Stores the transformation supplied when the BlockEntity is first constructed. This is used to determine if any
+     * transformations have been applied before the BlockEntity has been loaded from NBT. */
+    final DirectionTransformation initialTransformation;
+
+    /** Whether {@link #validate()} has been called.
+     * <p>
+     * This is used in determining whether parts should be initialized immediately upon loading from
+     * {@link #fromNbt(NbtCompound)} or if this container should wait until {@link #validate()} is called. If this value
+     * is <codd>true</codd>, then that means this container has already been validated and any subsequent calls to
+     * {@link #fromNbt(NbtCompound)} are being invoked on an already valid container and that
+     * {@link AbstractPart#onAdded(MultipartEventBus)} should be invoked immediately. */
+    boolean validated = false;
+
     /** Used by {@link #readInitialRenderData(NetByteBuf, IMsgReadCtx)} only as the server (for some reason) cannot send
      * that packet to only the player's who actually need it. */
     boolean hasInitialisedFromRemote = false;
@@ -174,9 +202,10 @@ public class PartContainer implements MultipartContainer {
 
     ImmutableList<PartModelKey> partModelKeys = ImmutableList.of();
 
-    public PartContainer(MultipartBlockEntity blockEntity) {
+    public PartContainer(MultipartBlockEntity blockEntity, DirectionTransformation initialTransformation) {
         assert blockEntity != null : "The given blockEntity was null!";
         this.blockEntity = blockEntity;
+        this.initialTransformation = initialTransformation;
     }
 
     // MultipartContainer
@@ -753,6 +782,12 @@ public class PartContainer implements MultipartContainer {
             LibMultiPart.LOGGER.info("PartContainer.fromNbt( " + getMultipartPos() + " ) {");
         }
         recalculateShape();
+
+        if (tag.contains("cachedTransformation")) {
+            cachedTransformation = MultipartBlock.TRANSFORMATION.parse(tag.getString("cachedTransformation"))
+                .orElse(DirectionTransformation.IDENTITY);
+        }
+
         nextId = Long.MIN_VALUE;
         boolean areIdsValid = true;
         NbtList allPartsTag = tag.getList("parts", new NbtCompound().getType());
@@ -825,10 +860,16 @@ public class PartContainer implements MultipartContainer {
         if (LibMultiPart.DEBUG) {
             LibMultiPart.LOGGER.info("}");
         }
+
+        // If we're already valid, then we can initialize parts now
+        if (validated) {
+            initParts();
+        }
     }
 
     NbtCompound toNbt() {
         NbtCompound tag = new NbtCompound();
+        tag.putString("cachedTransformation", MultipartBlock.TRANSFORMATION.name(cachedTransformation));
         NbtList partsTag = new NbtList();
         for (PartHolder part : parts) {
             partsTag.add(part.toNbt());
@@ -838,14 +879,26 @@ public class PartContainer implements MultipartContainer {
     }
 
     void validate() {
+        validated = true;
+        initParts();
+        eventBus.fireEvent(PartContainerState.VALIDATE);
+    }
+
+    /** Actually handles calling {@link AbstractPart#onAdded(MultipartEventBus)} as well as applying any not-yet-applied
+     * transformations. */
+    private void initParts() {
         eventBus.clearListeners();
         for (PartHolder holder : parts) {
             holder.part.onAdded(eventBus);
         }
-        eventBus.fireEvent(PartContainerState.VALIDATE);
+
+        // Now that we've (potentially) loaded from NBT, let's apply
+        // any transformations that were done before we loaded.
+        updateTransform(initialTransformation);
     }
 
     void invalidate() {
+        validated = false;
         eventBus.fireEvent(PartContainerState.INVALIDATE);
         delinkOtherBlockRequired();
     }
@@ -855,15 +908,106 @@ public class PartContainer implements MultipartContainer {
         delinkOtherBlockRequired();
     }
 
+    /** Checks if a transformation is valid for all parts in this container. */
+    boolean isTransformInvalid(DirectionTransformation transformation) {
+        PartTransformCheckEvent event = new PartTransformCheckEvent(transformation);
+        eventBus.fireEvent(event);
+        return event.isInvalid();
+    }
+
     void rotate(BlockRotation rotation) {
+        DirectionTransformation transformation = rotation.getDirectionTransformation();
+        if (isTransformInvalid(transformation)) {
+            return;
+        }
+
+        eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
+        callRotate(rotation);
+        eventBus.fireEvent(PartTransformEvent.create(transformation));
+        transformRequiredParts(transformation);
+        eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
+    }
+
+    private void callRotate(BlockRotation rotation) {
         for (PartHolder holder : parts) {
-            holder.rotate(rotation);
+            // Call the deprecated rotate method for backwards compatibility.
+            holder.part.rotate(rotation);
         }
     }
 
     void mirror(BlockMirror mirror) {
+        DirectionTransformation transformation = mirror.getDirectionTransformation();
+        if (isTransformInvalid(transformation)) {
+            return;
+        }
+
+        eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
+        callMirror(mirror);
+        eventBus.fireEvent(PartTransformEvent.create(transformation));
+        transformRequiredParts(transformation);
+        eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
+    }
+
+    private void callMirror(BlockMirror mirror) {
         for (PartHolder holder : parts) {
-            holder.mirror(mirror);
+            // Call the deprecated mirror method for backwards compatibility.
+            holder.part.mirror(mirror);
+        }
+    }
+
+    void transform(DirectionTransformation transformation) {
+        if (isTransformInvalid(transformation)) {
+            return;
+        }
+
+        eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
+        tryCallSimplifiedTransform(transformation);
+        eventBus.fireEvent(PartTransformEvent.create(transformation));
+        transformRequiredParts(transformation);
+        eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
+    }
+
+    private void transformRequiredParts(DirectionTransformation transformation) {
+        for (PartHolder holder : parts) {
+            holder.transformRequiredParts(transformation);
+        }
+    }
+
+    private void tryCallSimplifiedTransform(DirectionTransformation transformation) {
+        BlockRotation rotation = DirectionTransformationUtil.getRotation(transformation);
+        if (rotation != null) {
+            callRotate(rotation);
+        }
+
+        BlockMirror mirror = DirectionTransformationUtil.getMirror(transformation);
+        if (mirror != null) {
+            callMirror(mirror);
+        }
+    }
+
+    /** Used for tracking transformation changes and notifying contained parts if need be. */
+    void setCachedState(BlockState state) {
+        DirectionTransformation stateTransform = state.get(MultipartBlock.TRANSFORMATION);
+        updateTransform(stateTransform);
+    }
+
+    private void updateTransform(DirectionTransformation stateTransform) {
+        if (stateTransform != cachedTransformation) {
+            DirectionTransformation deltaTransform = DirectionTransformationUtil.getRelativeTransformation(cachedTransformation, stateTransform);
+            cachedTransformation = stateTransform;
+
+            // The actual value of the blockstate transform is meaningless, only the difference between it and the
+            // cached transform is used. This means we can just ignore invalid transformations without having to revert
+            // the blockstate or anything.
+            if (isTransformInvalid(deltaTransform)) {
+                return;
+            }
+
+            eventBus.fireEvent(PartPreTransformEvent.INSTANCE);
+            tryCallSimplifiedTransform(deltaTransform);
+            eventBus.fireEvent(PartTransformEvent.create(deltaTransform));
+            transformRequiredParts(deltaTransform);
+            eventBus.fireEvent(PartPostTransformEvent.INSTANCE);
         }
     }
 

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PartHolder.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PartHolder.java
@@ -26,6 +26,7 @@ import net.minecraft.util.BlockRotation;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.DirectionTransformation;
 import net.minecraft.util.math.Vec3d;
 
 import alexiil.mc.lib.net.IMsgReadCtx;
@@ -34,7 +35,6 @@ import alexiil.mc.lib.net.InvalidInputDataException;
 import alexiil.mc.lib.net.NetByteBuf;
 
 import alexiil.mc.lib.multipart.api.AbstractPart;
-import alexiil.mc.lib.multipart.api.AbstractPart.ItemDropTarget;
 import alexiil.mc.lib.multipart.api.MultipartContainer;
 import alexiil.mc.lib.multipart.api.MultipartContainer.MultipartCreator;
 import alexiil.mc.lib.multipart.api.MultipartHolder;
@@ -409,8 +409,7 @@ public final class PartHolder implements MultipartHolder {
         assert requiredParts == null : "Required Parts (" + requiredParts + ") wasn't fully cleared!";
     }
 
-    void rotate(BlockRotation rotation) {
-        part.rotate(rotation);
+    void rotateRequiredParts(BlockRotation rotation) {
         unloadedRequiredParts = rotate(unloadedRequiredParts, rotation);
         unloadedInverseRequiredParts = rotate(unloadedInverseRequiredParts, rotation);
     }
@@ -426,8 +425,7 @@ public final class PartHolder implements MultipartHolder {
         return to;
     }
 
-    void mirror(BlockMirror mirror) {
-        part.mirror(mirror);
+    void mirrorRequiredParts(BlockMirror mirror) {
         unloadedRequiredParts = mirror(unloadedRequiredParts, mirror);
         unloadedInverseRequiredParts = mirror(unloadedInverseRequiredParts, mirror);
     }
@@ -439,6 +437,22 @@ public final class PartHolder implements MultipartHolder {
         Set<PosPartId> to = identityHashSet();
         for (PosPartId pos : parts) {
             to.add(pos.mirror(container, mirror));
+        }
+        return to;
+    }
+
+    void transformRequiredParts(DirectionTransformation transformation) {
+        unloadedRequiredParts = transform(unloadedRequiredParts, transformation);
+        unloadedInverseRequiredParts = transform(unloadedInverseRequiredParts, transformation);
+    }
+
+    private Set<PosPartId> transform(Set<PosPartId> parts, DirectionTransformation transformation) {
+        if (parts == null) {
+            return null;
+        }
+        Set<PosPartId> to = identityHashSet();
+        for (PosPartId pos : parts) {
+            to.add(pos.transform(container, transformation));
         }
         return to;
     }

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
@@ -14,6 +14,8 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.DirectionTransformation;
+import net.minecraft.util.math.Vec3f;
 
 import alexiil.mc.lib.multipart.api.AbstractPart;
 import alexiil.mc.lib.multipart.api.MultipartHolder;
@@ -121,5 +123,19 @@ final class PosPartId {
             x = -x;
         }
         return new PosPartId(new BlockPos(x + f.getX(), pos.getY(), z + f.getZ()), uid);
+    }
+
+    public PosPartId transform(PartContainer from, DirectionTransformation transformation) {
+        if (transformation == DirectionTransformation.IDENTITY) {
+            return this;
+        }
+
+        BlockPos f = from.getMultipartPos();
+
+        Vec3f relPos = new Vec3f(pos.getX() - f.getX(), pos.getY() - f.getY(), pos.getZ() - f.getZ());
+        relPos.transform(transformation.getMatrix());
+        BlockPos transformedPos = new BlockPos(Math.round(relPos.getX()), Math.round(relPos.getY()), Math.round(relPos.getZ()));
+
+        return new PosPartId(transformedPos.add(f), uid);
     }
 }

--- a/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/PosPartId.java
@@ -111,11 +111,14 @@ final class PosPartId {
         BlockPos f = from.getMultipartPos();
         int x = pos.getX() - f.getX();
         int z = pos.getZ() - f.getZ();
+
+        // For some reason, BlockMirror.LEFT_RIGHT corresponds to inverting the Z-axis and BlockMirror.FRONT_BACK
+        // corresponds to inverting the X-axis.
         if (mirror == BlockMirror.LEFT_RIGHT) {
-            x = -x;
+            z = -z;
         } else {
             assert mirror == BlockMirror.FRONT_BACK;
-            z = -z;
+            x = -x;
         }
         return new PosPartId(new BlockPos(x + f.getX(), pos.getY(), z + f.getZ()), uid);
     }


### PR DESCRIPTION
# This PR

This PR is the 1.19 counterpart of #54, adding rotation, mirroring, and arbitrary part block-transformation support to the `0.8.x-1.19.x` branch of LibMultiPart.

# Features

Like #54, this PR contains support for:

* Handling when one part in a container can't be rotated/transformed in a way the container wants to be transformed.
* Handling when a transformation is applied to the BlockState before the BlockEntity has been created/loaded.

# Testing

I have tested and am using these changes in my distributed Wired Redstone versions. Create contraptions can properly move and rotate Wired Redstone parts. Create schematics also properly move and rotate Wired Redstone parts.

I am currently using this in my own version of LibMultiPart that I am distributing with Wired Redstone and have not run into any issues with it.

# Associated

* This PR fixes #52.
* This PR also fixes #58.
* This PR also fixes #59.