### PR TITLE
Add "AbstractPart.preConvertNativeMultipart"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 archivesBaseName = "LibMultiPart"
-version = "0.11.0"
+version = "0.11.1-pullreq67-pre.1"
 
 license {
     header = project.file('misc/LICENSE_HEADER.txt');

--- a/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
+++ b/src/main/java/alexiil/mc/lib/multipart/api/AbstractPart.java
@@ -178,6 +178,13 @@ public abstract class AbstractPart {
         container.recalculateShapeSynced();
     }
 
+    /** Called when a {@link NativeMultipart} {@link Block} is about to be converted to this {@link AbstractPart}. This
+     * method is invoked before any changes to the world are made, so you can get the current {@link NativeMultipart}
+     * {@link Block} (and {@link BlockEntity}, if applicable) from the world. */
+    public void preConvertNativeMultipart() {
+        // Nothing to do by default
+    }
+
     /** Called whenever this part was added to the {@link MultipartContainer}, either in
      * {@link BlockEntity#cancelRemoval()} or when it is manually added by an item.
      * <p>

--- a/src/main/java/alexiil/mc/lib/multipart/impl/MultipartUtilImpl.java
+++ b/src/main/java/alexiil/mc/lib/multipart/impl/MultipartUtilImpl.java
@@ -210,6 +210,11 @@ public final class MultipartUtilImpl {
                 // Cleanup the temporary additions
                 container.parts.clear();
 
+                // Inform the new parts that they are about to replace the existing NativeMultipart
+                for (PartHolder holder : existingHolders) {
+                    holder.part.preConvertNativeMultipart();
+                }
+
                 // Get the old block state for update notifications
                 BlockState oldState = world.getBlockState(pos);
 

--- a/src/main/resources/changelog/0.11.1.txt
+++ b/src/main/resources/changelog/0.11.1.txt
@@ -1,0 +1,3 @@
+Changes:
+
+* Added "AbstractPart.preConvertNativeMultipart", which is called just before a "NativeMultipart" gets replaced.


### PR DESCRIPTION
This allows `NativeMultipart` blocks to know just before they are actually converted to parts. As requested by `SquidDev` in discord.

Untested :/